### PR TITLE
feat(mobile): add navigation shell with tab bar (S-29)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tab navigator layout for the main app navigation.
+ *
+ * Defines 4 tabs matching the implementation plan:
+ * - Home: Dashboard with recent documents and quick actions
+ * - Documents: Document history list
+ * - Profiles: User profiles and dependents
+ * - Settings: App settings and preferences
+ *
+ * Uses a custom TabBar component styled with theme tokens.
+ * Test IDs are set automatically by the TabBar using the pattern `tab-{name}`.
+ */
+
+import { Tabs } from 'expo-router';
+
+import { useTheme } from '../../src/theme';
+import { TabBar } from '../../src/components/navigation/TabBar';
+import { TabBarIcon } from '../../src/components/navigation/TabBarIcon';
+
+export default function TabLayout() {
+  const { theme } = useTheme();
+
+  return (
+    <Tabs
+      tabBar={(props) => <TabBar {...props} />}
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: theme.colors.surface,
+        },
+        headerTintColor: theme.colors.onSurface,
+        headerTitleStyle: {
+          ...theme.typography.titleLarge,
+          color: theme.colors.onSurface,
+        },
+        headerShadowVisible: false,
+      }}
+    >
+      <Tabs.Screen
+        name="home"
+        options={{
+          title: 'Home',
+          headerTitle: 'FillIt',
+          tabBarLabel: 'Home',
+          tabBarAccessibilityLabel: 'Home dashboard tab',
+          tabBarIcon: ({ color, focused, size }) => (
+            <TabBarIcon
+              name={focused ? 'home' : 'home-outline'}
+              color={color}
+              size={size}
+              focused={focused}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="documents"
+        options={{
+          title: 'Documents',
+          tabBarLabel: 'Documents',
+          tabBarAccessibilityLabel: 'Documents list tab',
+          tabBarIcon: ({ color, focused, size }) => (
+            <TabBarIcon
+              name={focused ? 'document-text' : 'document-text-outline'}
+              color={color}
+              size={size}
+              focused={focused}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="profiles"
+        options={{
+          title: 'Profiles',
+          tabBarLabel: 'Profiles',
+          tabBarAccessibilityLabel: 'Profiles management tab',
+          tabBarIcon: ({ color, focused, size }) => (
+            <TabBarIcon
+              name={focused ? 'person' : 'person-outline'}
+              color={color}
+              size={size}
+              focused={focused}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Settings',
+          tabBarLabel: 'Settings',
+          tabBarAccessibilityLabel: 'App settings tab',
+          tabBarIcon: ({ color, focused, size }) => (
+            <TabBarIcon
+              name={focused ? 'settings' : 'settings-outline'}
+              color={color}
+              size={size}
+              focused={focused}
+            />
+          ),
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/apps/mobile/app/(tabs)/documents.tsx
+++ b/apps/mobile/app/(tabs)/documents.tsx
@@ -1,0 +1,76 @@
+/**
+ * Documents tab screen.
+ *
+ * Displays a list of all processed documents with their current status.
+ * Shows status chips (scanned, matched, exported, etc.) and allows
+ * users to tap into a document to continue processing or review.
+ */
+
+import { StyleSheet, Text, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../src/theme';
+
+export default function DocumentsScreen() {
+  const { theme } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: theme.colors.background, padding: theme.spacing.lg },
+      ]}
+      testID="documents-screen"
+    >
+      <View
+        style={[
+          styles.emptyState,
+          {
+            backgroundColor: theme.colors.surfaceVariant,
+            borderRadius: theme.radii.lg,
+            padding: theme.spacing['2xl'],
+          },
+        ]}
+      >
+        <Ionicons
+          name="folder-open-outline"
+          size={64}
+          color={theme.colors.onSurfaceVariant}
+          style={{ marginBottom: theme.spacing.lg }}
+        />
+        <Text
+          style={[
+            theme.typography.headlineMedium,
+            { color: theme.colors.onSurfaceVariant, textAlign: 'center' },
+          ]}
+        >
+          No Documents Yet
+        </Text>
+        <Text
+          style={[
+            theme.typography.bodyMedium,
+            {
+              color: theme.colors.onSurfaceVariant,
+              textAlign: 'center',
+              marginTop: theme.spacing.sm,
+            },
+          ]}
+        >
+          Scanned and imported documents will appear here.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emptyState: {
+    alignItems: 'center',
+    width: '100%',
+  },
+});

--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -1,0 +1,187 @@
+/**
+ * Home / Dashboard tab screen.
+ *
+ * Displays a welcome message, quick-action buttons (Scan, Import),
+ * recent documents, and a profile completeness indicator.
+ * This is the primary landing screen after app launch.
+ */
+
+import { StyleSheet, Text, View, Pressable, ScrollView } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../src/theme';
+
+export default function HomeScreen() {
+  const { theme } = useTheme();
+
+  return (
+    <ScrollView
+      style={[styles.screen, { backgroundColor: theme.colors.background }]}
+      contentContainerStyle={[styles.content, { padding: theme.spacing.lg }]}
+      testID="home-screen"
+    >
+      {/* Hero section */}
+      <View style={[styles.hero, { marginBottom: theme.spacing['2xl'] }]}>
+        <Text
+          style={[
+            theme.typography.displayMedium,
+            { color: theme.colors.onBackground, marginBottom: theme.spacing.xs },
+          ]}
+        >
+          FillIt
+        </Text>
+        <Text
+          style={[
+            theme.typography.bodyLarge,
+            { color: theme.colors.onSurfaceVariant, textAlign: 'center' },
+          ]}
+        >
+          Scan, fill, and export documents with ease.
+        </Text>
+      </View>
+
+      {/* Quick actions */}
+      <View style={[styles.quickActions, { gap: theme.spacing.md }]}>
+        <Pressable
+          style={({ pressed }) => [
+            styles.actionButton,
+            {
+              backgroundColor: theme.colors.primary,
+              borderRadius: theme.radii.lg,
+              padding: theme.spacing.lg,
+              ...theme.elevations.md,
+            },
+            pressed && styles.pressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Scan a document"
+          testID="action-scan"
+        >
+          <Ionicons name="scan" size={32} color={theme.colors.onPrimary} />
+          <Text
+            style={[
+              theme.typography.titleLarge,
+              { color: theme.colors.onPrimary, marginTop: theme.spacing.sm },
+            ]}
+          >
+            Scan
+          </Text>
+          <Text
+            style={[theme.typography.bodySmall, { color: theme.colors.onPrimary, opacity: 0.9 }]}
+          >
+            Use camera to scan
+          </Text>
+        </Pressable>
+
+        <Pressable
+          style={({ pressed }) => [
+            styles.actionButton,
+            {
+              backgroundColor: theme.colors.surface,
+              borderRadius: theme.radii.lg,
+              borderWidth: 1,
+              borderColor: theme.colors.outline,
+              padding: theme.spacing.lg,
+              ...theme.elevations.sm,
+            },
+            pressed && styles.pressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Import a document"
+          testID="action-import"
+        >
+          <Ionicons name="document-attach-outline" size={32} color={theme.colors.primary} />
+          <Text
+            style={[
+              theme.typography.titleLarge,
+              { color: theme.colors.onSurface, marginTop: theme.spacing.sm },
+            ]}
+          >
+            Import
+          </Text>
+          <Text style={[theme.typography.bodySmall, { color: theme.colors.onSurfaceVariant }]}>
+            PDF or image file
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* Recent documents placeholder */}
+      <View style={{ marginTop: theme.spacing['3xl'] }}>
+        <Text
+          style={[
+            theme.typography.headlineMedium,
+            { color: theme.colors.onBackground, marginBottom: theme.spacing.md },
+          ]}
+        >
+          Recent Documents
+        </Text>
+        <View
+          style={[
+            styles.emptyState,
+            {
+              backgroundColor: theme.colors.surfaceVariant,
+              borderRadius: theme.radii.lg,
+              padding: theme.spacing['2xl'],
+            },
+          ]}
+          testID="empty-recent-documents"
+        >
+          <Ionicons
+            name="documents-outline"
+            size={48}
+            color={theme.colors.onSurfaceVariant}
+            style={{ marginBottom: theme.spacing.md }}
+          />
+          <Text
+            style={[
+              theme.typography.bodyLarge,
+              { color: theme.colors.onSurfaceVariant, textAlign: 'center' },
+            ]}
+          >
+            No documents yet
+          </Text>
+          <Text
+            style={[
+              theme.typography.bodySmall,
+              {
+                color: theme.colors.onSurfaceVariant,
+                textAlign: 'center',
+                marginTop: theme.spacing.xs,
+              },
+            ]}
+          >
+            Scan or import your first document to get started.
+          </Text>
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+  },
+  hero: {
+    alignItems: 'center',
+    paddingTop: 8,
+  },
+  quickActions: {
+    flexDirection: 'row',
+  },
+  actionButton: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pressed: {
+    opacity: 0.8,
+    transform: [{ scale: 0.98 }],
+  },
+  emptyState: {
+    alignItems: 'center',
+  },
+});

--- a/apps/mobile/app/(tabs)/profiles.tsx
+++ b/apps/mobile/app/(tabs)/profiles.tsx
@@ -1,0 +1,178 @@
+/**
+ * Profiles tab screen.
+ *
+ * Manages user profiles and dependents. Shows the primary user profile
+ * card and dependent profiles. Provides navigation to edit profiles
+ * and add new dependents.
+ */
+
+import { StyleSheet, Text, View, Pressable } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../src/theme';
+
+export default function ProfilesScreen() {
+  const { theme } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: theme.colors.background, padding: theme.spacing.lg },
+      ]}
+      testID="profiles-screen"
+    >
+      {/* Profile completeness indicator placeholder */}
+      <View
+        style={[
+          styles.completenessCard,
+          {
+            backgroundColor: theme.colors.surface,
+            borderRadius: theme.radii.lg,
+            padding: theme.spacing.lg,
+            marginBottom: theme.spacing.lg,
+            ...theme.elevations.sm,
+          },
+        ]}
+        testID="profile-completeness"
+      >
+        <View style={styles.completenessHeader}>
+          <Ionicons name="shield-checkmark-outline" size={24} color={theme.colors.primary} />
+          <Text
+            style={[
+              theme.typography.titleLarge,
+              { color: theme.colors.onSurface, marginLeft: theme.spacing.sm },
+            ]}
+          >
+            Profile
+          </Text>
+        </View>
+        <Text
+          style={[
+            theme.typography.bodyMedium,
+            { color: theme.colors.onSurfaceVariant, marginTop: theme.spacing.sm },
+          ]}
+        >
+          Complete your profile to enable automatic form filling.
+        </Text>
+
+        {/* Progress bar placeholder */}
+        <View
+          style={[
+            styles.progressTrack,
+            {
+              backgroundColor: theme.colors.surfaceVariant,
+              borderRadius: theme.radii.full,
+              marginTop: theme.spacing.md,
+            },
+          ]}
+        >
+          <View
+            style={[
+              styles.progressFill,
+              {
+                backgroundColor: theme.colors.primary,
+                borderRadius: theme.radii.full,
+                width: '0%',
+              },
+            ]}
+          />
+        </View>
+        <Text
+          style={[
+            theme.typography.labelSmall,
+            { color: theme.colors.onSurfaceVariant, marginTop: theme.spacing.xs },
+          ]}
+        >
+          0% complete
+        </Text>
+      </View>
+
+      {/* Empty state / Setup prompt */}
+      <View
+        style={[
+          styles.emptyState,
+          {
+            backgroundColor: theme.colors.surfaceVariant,
+            borderRadius: theme.radii.lg,
+            padding: theme.spacing['2xl'],
+          },
+        ]}
+      >
+        <Ionicons
+          name="people-outline"
+          size={64}
+          color={theme.colors.onSurfaceVariant}
+          style={{ marginBottom: theme.spacing.lg }}
+        />
+        <Text
+          style={[
+            theme.typography.headlineMedium,
+            { color: theme.colors.onSurfaceVariant, textAlign: 'center' },
+          ]}
+        >
+          Set Up Your Profile
+        </Text>
+        <Text
+          style={[
+            theme.typography.bodyMedium,
+            {
+              color: theme.colors.onSurfaceVariant,
+              textAlign: 'center',
+              marginTop: theme.spacing.sm,
+            },
+          ]}
+        >
+          Add your details so FillIt can auto-fill forms for you.
+        </Text>
+        <Pressable
+          style={({ pressed }) => [
+            styles.setupButton,
+            {
+              backgroundColor: theme.colors.primary,
+              borderRadius: theme.radii.md,
+              marginTop: theme.spacing.lg,
+              paddingVertical: theme.spacing.md,
+              paddingHorizontal: theme.spacing['2xl'],
+            },
+            pressed && styles.pressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Set up your profile"
+          testID="setup-profile-button"
+        >
+          <Text style={[theme.typography.labelLarge, { color: theme.colors.onPrimary }]}>
+            Get Started
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  completenessCard: {},
+  completenessHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  progressTrack: {
+    height: 6,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+  },
+  emptyState: {
+    alignItems: 'center',
+  },
+  setupButton: {
+    alignItems: 'center',
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+});

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,0 +1,193 @@
+/**
+ * Settings tab screen.
+ *
+ * Provides app configuration options including theme toggle,
+ * notification preferences, data management, and app info.
+ */
+
+import { StyleSheet, Text, View, Pressable, ScrollView } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { type ComponentProps } from 'react';
+
+import { useTheme } from '../../src/theme';
+
+/** Props for a single settings row */
+interface SettingsRowProps {
+  /** Ionicons icon name */
+  readonly icon: ComponentProps<typeof Ionicons>['name'];
+  /** Row label text */
+  readonly label: string;
+  /** Optional description below the label */
+  readonly description?: string;
+  /** Optional right-side content (e.g., current value) */
+  readonly value?: string;
+  /** Press handler */
+  readonly onPress?: () => void;
+  /** Test ID for e2e testing */
+  readonly testID?: string;
+}
+
+function SettingsRow({ icon, label, description, value, onPress, testID }: SettingsRowProps) {
+  const { theme } = useTheme();
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.row,
+        {
+          backgroundColor: theme.colors.surface,
+          paddingVertical: theme.spacing.md,
+          paddingHorizontal: theme.spacing.lg,
+        },
+        pressed && onPress && styles.rowPressed,
+      ]}
+      onPress={onPress}
+      disabled={!onPress}
+      accessibilityRole={onPress ? 'button' : 'text'}
+      accessibilityLabel={label}
+      testID={testID}
+    >
+      <Ionicons
+        name={icon}
+        size={22}
+        color={theme.colors.onSurfaceVariant}
+        style={{ marginRight: theme.spacing.md }}
+      />
+      <View style={styles.rowContent}>
+        <Text style={[theme.typography.bodyLarge, { color: theme.colors.onSurface }]}>{label}</Text>
+        {description ? (
+          <Text
+            style={[
+              theme.typography.bodySmall,
+              { color: theme.colors.onSurfaceVariant, marginTop: 2 },
+            ]}
+          >
+            {description}
+          </Text>
+        ) : null}
+      </View>
+      {value ? (
+        <Text
+          style={[
+            theme.typography.bodyMedium,
+            { color: theme.colors.onSurfaceVariant, marginLeft: theme.spacing.sm },
+          ]}
+        >
+          {value}
+        </Text>
+      ) : null}
+      {onPress ? (
+        <Ionicons
+          name="chevron-forward"
+          size={20}
+          color={theme.colors.onSurfaceVariant}
+          style={{ marginLeft: theme.spacing.sm }}
+        />
+      ) : null}
+    </Pressable>
+  );
+}
+
+function SettingsSectionHeader({ title }: { readonly title: string }) {
+  const { theme } = useTheme();
+  return (
+    <Text
+      style={[
+        theme.typography.labelMedium,
+        {
+          color: theme.colors.primary,
+          paddingHorizontal: theme.spacing.lg,
+          paddingTop: theme.spacing.xl,
+          paddingBottom: theme.spacing.xs,
+        },
+      ]}
+    >
+      {title}
+    </Text>
+  );
+}
+
+export default function SettingsScreen() {
+  const { theme, colorMode, setColorMode } = useTheme();
+
+  const colorModeLabel =
+    colorMode === 'system' ? 'System' : colorMode === 'dark' ? 'Dark' : 'Light';
+
+  const handleThemeToggle = () => {
+    // Cycle through: system -> light -> dark -> system
+    if (colorMode === 'system') {
+      setColorMode('light');
+    } else if (colorMode === 'light') {
+      setColorMode('dark');
+    } else {
+      setColorMode('system');
+    }
+  };
+
+  return (
+    <ScrollView
+      style={[styles.screen, { backgroundColor: theme.colors.background }]}
+      testID="settings-screen"
+    >
+      <SettingsSectionHeader title="APPEARANCE" />
+      <SettingsRow
+        icon="color-palette-outline"
+        label="Theme"
+        description="Choose light, dark, or system default"
+        value={colorModeLabel}
+        onPress={handleThemeToggle}
+        testID="settings-theme"
+      />
+
+      <SettingsSectionHeader title="DATA" />
+      <SettingsRow
+        icon="shield-checkmark-outline"
+        label="Security"
+        description="Biometric lock and encryption"
+        testID="settings-security"
+      />
+      <View style={[styles.divider, { backgroundColor: theme.colors.divider }]} />
+      <SettingsRow
+        icon="cloud-upload-outline"
+        label="Backup"
+        description="Google Drive or iCloud backup"
+        testID="settings-backup"
+      />
+
+      <SettingsSectionHeader title="ABOUT" />
+      <SettingsRow
+        icon="information-circle-outline"
+        label="Version"
+        value="0.1.0"
+        testID="settings-version"
+      />
+      <View style={[styles.divider, { backgroundColor: theme.colors.divider }]} />
+      <SettingsRow icon="document-text-outline" label="Privacy Policy" testID="settings-privacy" />
+      <View style={[styles.divider, { backgroundColor: theme.colors.divider }]} />
+      <SettingsRow icon="help-circle-outline" label="Help & Support" testID="settings-help" />
+
+      {/* Bottom spacer for safe area */}
+      <View style={{ height: theme.spacing['3xl'] }} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  rowPressed: {
+    opacity: 0.7,
+  },
+  rowContent: {
+    flex: 1,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: 54, // icon width + margin to align with text
+  },
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,3 +1,12 @@
+/**
+ * Root layout for the FillIt mobile app.
+ *
+ * Wraps the entire app with ThemeProvider and handles:
+ * - Font loading with splash screen
+ * - Theme-aware status bar
+ * - Top-level Stack navigator containing (tabs) group and modal screens
+ */
+
 import { View } from 'react-native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -14,6 +23,22 @@ function ThemedStatusBar() {
   return <StatusBar style={isDark ? 'light' : 'dark'} />;
 }
 
+function RootNavigator() {
+  const { theme } = useTheme();
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: theme.colors.background },
+      }}
+    >
+      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      <Stack.Screen name="__e2e" options={{ headerShown: true, headerTitle: 'E2E Tests' }} />
+    </Stack>
+  );
+}
+
 export default function RootLayout() {
   const { fontsLoaded, fontError, onLayoutRootView } = useFontsLoaded();
 
@@ -25,12 +50,7 @@ export default function RootLayout() {
     <ThemeProvider initialColorMode="system">
       <View style={{ flex: 1 }} onLayout={onLayoutRootView}>
         <ThemedStatusBar />
-        <Stack
-          screenOptions={{
-            headerShown: true,
-            headerTitle: 'FillIt',
-          }}
-        />
+        <RootNavigator />
       </View>
     </ThemeProvider>
   );

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,40 +1,12 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { useTheme } from '../src/theme';
+/**
+ * Root index screen — redirects to the (tabs) group.
+ *
+ * This file handles the entry redirect from `/` to `/(tabs)/home`
+ * so the app always lands on the Home tab.
+ */
 
-export default function HomeScreen() {
-  const { theme } = useTheme();
+import { Redirect } from 'expo-router';
 
-  return (
-    <View
-      style={[
-        styles.container,
-        { backgroundColor: theme.colors.background, padding: theme.spacing.lg },
-      ]}
-    >
-      <Text
-        style={[
-          theme.typography.displayMedium,
-          { color: theme.colors.onBackground, marginBottom: theme.spacing.sm },
-        ]}
-      >
-        FillIt
-      </Text>
-      <Text
-        style={[
-          theme.typography.bodyLarge,
-          { color: theme.colors.onSurfaceVariant, textAlign: 'center' },
-        ]}
-      >
-        Scan, fill, and export documents with ease.
-      </Text>
-    </View>
-  );
+export default function IndexScreen() {
+  return <Redirect href="/(tabs)/home" />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,6 +20,7 @@
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo-google-fonts/jetbrains-mono": "^0.4.1",
     "@expo/metro-runtime": "~55.0.6",
+    "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^11.5.2",
     "expo": "~55.0.8",

--- a/apps/mobile/src/components/navigation/TabBar.tsx
+++ b/apps/mobile/src/components/navigation/TabBar.tsx
@@ -1,0 +1,192 @@
+/**
+ * Custom tab bar component for the bottom navigation.
+ *
+ * Styled with the FillIt design system tokens for consistent
+ * theming across light and dark modes. Includes proper
+ * accessibility labels and roles for screen reader support.
+ */
+
+import { type ReactNode } from 'react';
+import { View, Pressable, Text, StyleSheet, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useTheme } from '../../theme';
+
+/** Height of the tab bar content area (excluding safe area inset) */
+const TAB_BAR_HEIGHT = 56;
+
+/** Route shape from the tab navigator state */
+interface TabRoute {
+  readonly key: string;
+  readonly name: string;
+  readonly params?: object;
+}
+
+/** Options we read from each tab descriptor */
+interface TabOptions {
+  readonly tabBarLabel?: string | ((...args: unknown[]) => ReactNode);
+  readonly title?: string;
+  readonly tabBarAccessibilityLabel?: string;
+  readonly tabBarTestID?: string;
+  readonly tabBarIcon?: (props: { focused: boolean; color: string; size: number }) => ReactNode;
+}
+
+/**
+ * Props passed to the custom tab bar by the bottom tab navigator.
+ *
+ * We use a permissive record type for descriptors and navigation
+ * to avoid tight coupling with @react-navigation/bottom-tabs types,
+ * which are a transitive dependency not directly accessible in pnpm strict mode.
+ */
+export interface TabBarProps {
+  readonly state: {
+    readonly index: number;
+    readonly routes: readonly TabRoute[];
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly descriptors: Record<string, { readonly options: any }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly navigation: any;
+  /** Accept additional props from the navigator (e.g., insets) */
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Custom bottom tab bar with theme-aware styling.
+ *
+ * Features:
+ * - Theme token-based colors (light/dark mode)
+ * - Safe area inset handling for devices with home indicators
+ * - Elevation shadow on the top edge
+ * - Accessible tab buttons with labels and roles
+ * - Pressed state feedback
+ */
+export function TabBar({ state, descriptors, navigation }: TabBarProps) {
+  const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: theme.colors.surface,
+          borderTopColor: theme.colors.divider,
+          paddingBottom: insets.bottom,
+          ...theme.elevations.sm,
+        },
+      ]}
+      accessibilityRole="tablist"
+      testID="tab-bar"
+    >
+      {state.routes.map((route, index) => {
+        const descriptor = descriptors[route.key];
+        if (!descriptor) return null;
+        const options = descriptor.options as TabOptions;
+        const label =
+          typeof options.tabBarLabel === 'string'
+            ? options.tabBarLabel
+            : typeof options.title === 'string'
+              ? options.title
+              : route.name;
+
+        const isFocused = state.index === index;
+
+        const onPress = () => {
+          const event = navigation.emit({
+            type: 'tabPress',
+            target: route.key,
+            canPreventDefault: true,
+          });
+
+          if (!isFocused && !event.defaultPrevented) {
+            navigation.navigate(route.name, route.params);
+          }
+        };
+
+        const onLongPress = () => {
+          navigation.emit({
+            type: 'tabLongPress',
+            target: route.key,
+          });
+        };
+
+        const activeColor = theme.colors.primary;
+        const inactiveColor = theme.colors.onSurfaceVariant;
+        const color = isFocused ? activeColor : inactiveColor;
+
+        return (
+          <Pressable
+            key={route.key}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: isFocused }}
+            accessibilityLabel={options.tabBarAccessibilityLabel ?? `${label} tab`}
+            testID={options.tabBarTestID ?? `tab-${route.name}`}
+            onPress={onPress}
+            onLongPress={onLongPress}
+            style={({ pressed }) => [
+              styles.tab,
+              pressed && styles.tabPressed,
+              isFocused && {
+                backgroundColor:
+                  theme.colorScheme === 'dark'
+                    ? 'rgba(94, 166, 255, 0.08)'
+                    : 'rgba(0, 102, 204, 0.06)',
+              },
+            ]}
+          >
+            {options.tabBarIcon?.({
+              focused: isFocused,
+              color,
+              size: 24,
+            })}
+            <Text
+              style={[
+                styles.label,
+                theme.typography.labelSmall,
+                { color },
+                isFocused && styles.labelFocused,
+              ]}
+              numberOfLines={1}
+            >
+              {label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    ...Platform.select({
+      android: {
+        elevation: 8,
+      },
+      default: {},
+    }),
+  },
+  tab: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 8,
+    paddingBottom: 4,
+    minHeight: TAB_BAR_HEIGHT,
+    borderRadius: 8,
+    marginHorizontal: 2,
+  },
+  tabPressed: {
+    opacity: 0.7,
+  },
+  label: {
+    marginTop: 2,
+    textAlign: 'center',
+  },
+  labelFocused: {
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/components/navigation/TabBarIcon.tsx
+++ b/apps/mobile/src/components/navigation/TabBarIcon.tsx
@@ -1,0 +1,50 @@
+/**
+ * TabBarIcon component for the bottom tab navigator.
+ *
+ * Renders a Ionicons icon with theme-aware colors.
+ * Supports focused/unfocused states for active tab indication.
+ */
+
+import { type ComponentProps } from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { StyleSheet } from 'react-native';
+
+/** Props for the TabBarIcon component */
+export interface TabBarIconProps {
+  /** Ionicons icon name */
+  readonly name: ComponentProps<typeof Ionicons>['name'];
+  /** Icon color (set by tab navigator based on focus state) */
+  readonly color: string;
+  /** Icon size in dp */
+  readonly size?: number;
+  /** Whether this tab is currently focused */
+  readonly focused?: boolean;
+}
+
+/**
+ * Renders a tab bar icon using Ionicons.
+ *
+ * The icon automatically adjusts opacity based on focus state
+ * for a subtle visual cue beyond color changes.
+ */
+export function TabBarIcon({ name, color, size = 24, focused }: TabBarIconProps) {
+  return (
+    <Ionicons
+      name={name}
+      size={size}
+      color={color}
+      style={[styles.icon, focused === false && styles.unfocused]}
+      accessibilityElementsHidden
+      importantForAccessibility="no"
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  icon: {
+    marginBottom: 2,
+  },
+  unfocused: {
+    opacity: 0.8,
+  },
+});

--- a/apps/mobile/src/components/navigation/__tests__/TabBar.test.tsx
+++ b/apps/mobile/src/components/navigation/__tests__/TabBar.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for the TabBar component.
+ *
+ * Verifies the component exports and basic contract.
+ * Uses mocks for React Native and navigation dependencies
+ * to avoid Vitest parse issues with Flow/JSX in native modules.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock react-native
+vi.mock('react-native', () => ({
+  View: vi.fn(() => null),
+  Pressable: vi.fn(() => null),
+  Text: vi.fn(() => null),
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 0.5,
+  },
+  Platform: {
+    select: vi.fn((obj: Record<string, unknown>) => obj.default ?? {}),
+  },
+}));
+
+// Mock react-native-safe-area-context
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: vi.fn(() => ({ top: 0, right: 0, bottom: 0, left: 0 })),
+}));
+
+// Mock the theme hook
+vi.mock('../../../theme', () => ({
+  useTheme: vi.fn(() => ({
+    theme: {
+      colors: {
+        surface: '#FFFFFF',
+        divider: '#E0E0E0',
+        primary: '#0066CC',
+        onSurfaceVariant: '#666666',
+        onPrimary: '#FFFFFF',
+      },
+      colorScheme: 'light',
+      typography: {
+        labelSmall: { fontSize: 10, lineHeight: 14 },
+      },
+      elevations: {
+        sm: {
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.1,
+          shadowRadius: 2,
+          elevation: 2,
+        },
+      },
+    },
+  })),
+}));
+
+import { TabBar } from '../TabBar';
+
+describe('TabBar', () => {
+  it('should export a named TabBar function', () => {
+    expect(typeof TabBar).toBe('function');
+  });
+
+  it('should be a React function component', () => {
+    // React function components accept props as the first argument
+    expect(TabBar.length).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/mobile/src/components/navigation/__tests__/TabBarIcon.test.tsx
+++ b/apps/mobile/src/components/navigation/__tests__/TabBarIcon.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for the TabBarIcon component.
+ *
+ * Verifies the component exports and interface contract.
+ * Uses mocks for React Native and @expo/vector-icons to avoid
+ * Vitest parse issues with Flow/JSX in native modules.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock react-native
+vi.mock('react-native', () => ({
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+  },
+}));
+
+// Mock @expo/vector-icons/Ionicons
+vi.mock('@expo/vector-icons/Ionicons', () => ({
+  default: vi.fn(() => null),
+}));
+
+import { TabBarIcon, type TabBarIconProps } from '../TabBarIcon';
+
+describe('TabBarIcon', () => {
+  it('should export a named TabBarIcon function', () => {
+    expect(typeof TabBarIcon).toBe('function');
+  });
+
+  it('should be callable with required props', () => {
+    expect(() => {
+      TabBarIcon({ name: 'home', color: '#000000' });
+    }).not.toThrow();
+  });
+
+  it('should be callable with all props', () => {
+    expect(() => {
+      TabBarIcon({
+        name: 'home-outline',
+        color: '#FFFFFF',
+        size: 28,
+        focused: true,
+      });
+    }).not.toThrow();
+  });
+
+  it('should accept unfocused state', () => {
+    expect(() => {
+      TabBarIcon({
+        name: 'settings-outline',
+        color: '#666666',
+        focused: false,
+      });
+    }).not.toThrow();
+  });
+
+  it('should satisfy the TabBarIconProps interface', () => {
+    const props: TabBarIconProps = {
+      name: 'document-text',
+      color: '#0066CC',
+      size: 24,
+      focused: true,
+    };
+    expect(props.name).toBe('document-text');
+    expect(props.color).toBe('#0066CC');
+    expect(props.size).toBe(24);
+    expect(props.focused).toBe(true);
+  });
+});

--- a/apps/mobile/src/components/navigation/__tests__/index.test.ts
+++ b/apps/mobile/src/components/navigation/__tests__/index.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the navigation components barrel export.
+ *
+ * Verifies all expected exports are available.
+ * Uses mocks for React Native and icon dependencies.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock react-native
+vi.mock('react-native', () => ({
+  View: vi.fn(() => null),
+  Pressable: vi.fn(() => null),
+  Text: vi.fn(() => null),
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 0.5,
+  },
+  Platform: {
+    select: vi.fn((obj: Record<string, unknown>) => obj.default ?? {}),
+  },
+}));
+
+// Mock @expo/vector-icons/Ionicons
+vi.mock('@expo/vector-icons/Ionicons', () => ({
+  default: vi.fn(() => null),
+}));
+
+// Mock react-native-safe-area-context
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: vi.fn(() => ({ top: 0, right: 0, bottom: 0, left: 0 })),
+}));
+
+// Mock the theme hook
+vi.mock('../../../theme', () => ({
+  useTheme: vi.fn(() => ({
+    theme: {
+      colors: {
+        surface: '#FFFFFF',
+        divider: '#E0E0E0',
+        primary: '#0066CC',
+        onSurfaceVariant: '#666666',
+      },
+      colorScheme: 'light',
+      typography: {
+        labelSmall: { fontSize: 10, lineHeight: 14 },
+      },
+      elevations: {
+        sm: {
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.1,
+          shadowRadius: 2,
+          elevation: 2,
+        },
+      },
+    },
+  })),
+}));
+
+import { TabBar, TabBarIcon } from '../index';
+
+describe('navigation barrel export', () => {
+  it('should export TabBar', () => {
+    expect(TabBar).toBeDefined();
+    expect(typeof TabBar).toBe('function');
+  });
+
+  it('should export TabBarIcon', () => {
+    expect(TabBarIcon).toBeDefined();
+    expect(typeof TabBarIcon).toBe('function');
+  });
+});

--- a/apps/mobile/src/components/navigation/index.ts
+++ b/apps/mobile/src/components/navigation/index.ts
@@ -1,0 +1,2 @@
+export { TabBar } from './TabBar';
+export { TabBarIcon, type TabBarIconProps } from './TabBarIcon';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@expo/metro-runtime':
         specifier: ~55.0.6
         version: 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@expo/vector-icons':
+        specifier: ^15.1.1
+        version: 15.1.1(expo-font@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@fillit/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## Summary
- 4-tab navigation: Home, Documents, Profiles, Settings
- Custom TabBar component with theme tokens, focused/pressed states
- Ionicons with filled (focused) and outline (unfocused) variants
- Home dashboard with quick actions, Settings with theme cycling
- Dark/light mode, full accessibility (tab roles, selected state)
- Expo Router file-based routing with (tabs) group

Closes #30

## Test plan
- [x] 9 unit tests for TabBar and TabBarIcon components
- [ ] Verify tab navigation works on device
- [ ] Test theme cycling in Settings
- [ ] Screen reader tab navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)