### PR TITLE
feat(mobile): profile edit screen with unsaved changes warning (S-32)

### DIFF
--- a/apps/mobile/app/profile/create.tsx
+++ b/apps/mobile/app/profile/create.tsx
@@ -2,16 +2,16 @@
  * Profile creation screen.
  *
  * Renders the ProfileForm for creating a new primary profile.
- * Navigates back to the profiles tab on successful creation.
+ * Shows success feedback and navigates back on completion.
  */
 
 import { useCallback } from 'react';
-import { View, Text, Pressable, StyleSheet, Alert } from 'react-native';
+import { View, StyleSheet, Alert } from 'react-native';
 import { router } from 'expo-router';
-import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { useTheme } from '../../src/theme';
 import { ProfileForm } from '../../src/components/profile';
+import { ScreenHeader } from '../../src/components/profile/ScreenHeader';
 import { useProfileStore } from '../../src/stores/profile-store';
 import type { CreateProfileInput } from '../../src/services/storage/profileCrud';
 
@@ -24,7 +24,9 @@ export default function CreateProfileScreen() {
     async (data: CreateProfileInput) => {
       try {
         await createProfile(data);
-        router.back();
+        Alert.alert('Profile Created', 'Your profile has been set up successfully.', [
+          { text: 'OK', onPress: () => router.back() },
+        ]);
       } catch (err) {
         Alert.alert(
           'Error',
@@ -37,40 +39,8 @@ export default function CreateProfileScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      {/* Header */}
-      <View
-        style={[
-          styles.header,
-          {
-            backgroundColor: theme.colors.surface,
-            paddingHorizontal: theme.spacing.lg,
-            paddingTop: theme.spacing['3xl'],
-            paddingBottom: theme.spacing.md,
-            borderBottomWidth: 1,
-            borderBottomColor: theme.colors.outline,
-          },
-        ]}
-      >
-        <Pressable
-          onPress={() => router.back()}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel="Go back"
-          testID="back-button"
-        >
-          <Ionicons name="arrow-back" size={24} color={theme.colors.onSurface} />
-        </Pressable>
-        <Text
-          style={[
-            theme.typography.titleLarge,
-            { color: theme.colors.onSurface, marginLeft: theme.spacing.md, flex: 1 },
-          ]}
-        >
-          Create Profile
-        </Text>
-      </View>
-
-      <ProfileForm onSubmit={handleSubmit} isSaving={isMutating} />
+      <ScreenHeader title="Create Profile" onBack={() => router.back()} />
+      <ProfileForm onSubmit={handleSubmit} onCancel={() => router.back()} isSaving={isMutating} />
     </View>
   );
 }
@@ -78,9 +48,5 @@ export default function CreateProfileScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
   },
 });

--- a/apps/mobile/app/profile/edit.tsx
+++ b/apps/mobile/app/profile/edit.tsx
@@ -2,31 +2,55 @@
  * Profile edit screen.
  *
  * Renders the ProfileForm pre-filled with the active profile's data.
- * Navigates back on successful update.
+ * Warns on unsaved changes and shows success feedback on save.
  */
 
-import { useCallback } from 'react';
-import { View, Text, Pressable, StyleSheet, Alert } from 'react-native';
+import { useCallback, useRef } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
 import { router } from 'expo-router';
-import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { useTheme } from '../../src/theme';
 import { ProfileForm } from '../../src/components/profile';
+import { ScreenHeader } from '../../src/components/profile/ScreenHeader';
 import { useProfileStore, selectActiveProfile } from '../../src/stores/profile-store';
 import type { CreateProfileInput } from '../../src/services/storage/profileCrud';
+
+function confirmDiscard(): Promise<boolean> {
+  return new Promise((resolve) => {
+    Alert.alert('Discard Changes?', 'You have unsaved changes. Are you sure you want to go back?', [
+      { text: 'Keep Editing', style: 'cancel', onPress: () => resolve(false) },
+      { text: 'Discard', style: 'destructive', onPress: () => resolve(true) },
+    ]);
+  });
+}
 
 export default function EditProfileScreen() {
   const { theme } = useTheme();
   const profile = useProfileStore(selectActiveProfile);
   const updateProfile = useProfileStore((s) => s.updateProfile);
   const isMutating = useProfileStore((s) => s.mutationCount > 0);
+  const isDirtyRef = useRef(false);
+
+  const handleDirtyChange = useCallback((dirty: boolean) => {
+    isDirtyRef.current = dirty;
+  }, []);
+
+  const handleBack = useCallback(async () => {
+    if (isDirtyRef.current) {
+      const shouldDiscard = await confirmDiscard();
+      if (!shouldDiscard) return;
+    }
+    router.back();
+  }, []);
 
   const handleSubmit = useCallback(
     async (data: CreateProfileInput) => {
       if (!profile) return;
       try {
         await updateProfile(profile.id, data);
-        router.back();
+        Alert.alert('Profile Updated', 'Your profile has been saved successfully.', [
+          { text: 'OK', onPress: () => router.back() },
+        ]);
       } catch (err) {
         Alert.alert(
           'Error',
@@ -49,40 +73,14 @@ export default function EditProfileScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
-      {/* Header */}
-      <View
-        style={[
-          styles.header,
-          {
-            backgroundColor: theme.colors.surface,
-            paddingHorizontal: theme.spacing.lg,
-            paddingTop: theme.spacing['3xl'],
-            paddingBottom: theme.spacing.md,
-            borderBottomWidth: 1,
-            borderBottomColor: theme.colors.outline,
-          },
-        ]}
-      >
-        <Pressable
-          onPress={() => router.back()}
-          hitSlop={12}
-          accessibilityRole="button"
-          accessibilityLabel="Go back"
-          testID="back-button"
-        >
-          <Ionicons name="arrow-back" size={24} color={theme.colors.onSurface} />
-        </Pressable>
-        <Text
-          style={[
-            theme.typography.titleLarge,
-            { color: theme.colors.onSurface, marginLeft: theme.spacing.md, flex: 1 },
-          ]}
-        >
-          Edit Profile
-        </Text>
-      </View>
-
-      <ProfileForm initialData={profile} onSubmit={handleSubmit} isSaving={isMutating} />
+      <ScreenHeader title="Edit Profile" onBack={handleBack} />
+      <ProfileForm
+        initialData={profile}
+        onSubmit={handleSubmit}
+        onCancel={handleBack}
+        onDirtyChange={handleDirtyChange}
+        isSaving={isMutating}
+      />
     </View>
   );
 }
@@ -93,10 +91,6 @@ const styles = StyleSheet.create({
   },
   center: {
     justifyContent: 'center',
-    alignItems: 'center',
-  },
-  header: {
-    flexDirection: 'row',
     alignItems: 'center',
   },
 });

--- a/apps/mobile/src/components/profile/ProfileForm.tsx
+++ b/apps/mobile/src/components/profile/ProfileForm.tsx
@@ -6,6 +6,7 @@
  * DOB, gender, and citizenship.
  */
 
+import { useEffect } from 'react';
 import { ScrollView, KeyboardAvoidingView, Platform, StyleSheet } from 'react-native';
 import type { UserProfile } from '@fillit/shared';
 
@@ -23,14 +24,26 @@ import {
 export interface ProfileFormProps {
   readonly initialData?: UserProfile;
   readonly onSubmit: (data: CreateProfileInput) => Promise<void>;
+  readonly onCancel?: () => void;
+  readonly onDirtyChange?: (isDirty: boolean) => void;
   readonly isSaving?: boolean;
 }
 
-export function ProfileForm({ initialData, onSubmit, isSaving = false }: ProfileFormProps) {
+export function ProfileForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  onDirtyChange,
+  isSaving = false,
+}: ProfileFormProps) {
   const { theme } = useTheme();
   const isEditing = Boolean(initialData);
-  const { form, errors, updateField, handleSaIdChange, handleSubmit, saIdHelperText } =
+  const { form, errors, isDirty, updateField, handleSaIdChange, handleSubmit, saIdHelperText } =
     useProfileForm(initialData, onSubmit);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   return (
     <KeyboardAvoidingView
@@ -62,6 +75,17 @@ export function ProfileForm({ initialData, onSubmit, isSaving = false }: Profile
           size="lg"
           testID="submit-profile"
         />
+        {onCancel ? (
+          <Button
+            label="Cancel"
+            variant="ghost"
+            onPress={onCancel}
+            fullWidth
+            size="md"
+            style={{ marginTop: theme.spacing.sm }}
+            testID="cancel-profile"
+          />
+        ) : null}
       </ScrollView>
     </KeyboardAvoidingView>
   );

--- a/apps/mobile/src/components/profile/ScreenHeader.tsx
+++ b/apps/mobile/src/components/profile/ScreenHeader.tsx
@@ -1,0 +1,59 @@
+/**
+ * Reusable header bar for profile screens (create/edit).
+ */
+
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../theme';
+
+interface ScreenHeaderProps {
+  readonly title: string;
+  readonly onBack: () => void;
+}
+
+export function ScreenHeader({ title, onBack }: ScreenHeaderProps) {
+  const { theme } = useTheme();
+  return (
+    <View
+      style={[
+        styles.header,
+        {
+          backgroundColor: theme.colors.surface,
+          paddingHorizontal: theme.spacing.lg,
+          paddingTop: theme.spacing['3xl'],
+          paddingBottom: theme.spacing.md,
+          borderBottomWidth: 1,
+          borderBottomColor: theme.colors.outline,
+        },
+      ]}
+    >
+      <Pressable
+        onPress={onBack}
+        hitSlop={12}
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+        testID="back-button"
+      >
+        <Ionicons name="arrow-back" size={24} color={theme.colors.onSurface} />
+      </Pressable>
+      <Text
+        style={[
+          theme.typography.titleLarge,
+          { color: theme.colors.onSurface, marginLeft: theme.spacing.md, flex: 1 },
+        ]}
+      >
+        {title}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+
+ScreenHeader.displayName = 'ScreenHeader';

--- a/apps/mobile/src/components/profile/useProfileForm.ts
+++ b/apps/mobile/src/components/profile/useProfileForm.ts
@@ -4,7 +4,7 @@
  * Handles field updates, SA ID smart-fill, validation, and submission.
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import type { UserProfile } from '@fillit/shared';
 
 import type { CreateProfileInput } from '../../services/storage/profileCrud';
@@ -24,6 +24,9 @@ export function useProfileForm(
   const [form, setForm] = useState<ProfileFormData>(() => initFormData(initialData));
   const [errors, setErrors] = useState<FormErrors>({});
   const [smartFillApplied, setSmartFillApplied] = useState(false);
+  const initialSnapshot = useRef(JSON.stringify(initFormData(initialData)));
+
+  const isDirty = useMemo(() => JSON.stringify(form) !== initialSnapshot.current, [form]);
 
   const updateField = useCallback(
     <K extends keyof ProfileFormData>(field: K, value: ProfileFormData[K]) => {
@@ -83,5 +86,5 @@ export function useProfileForm(
     [smartFillApplied],
   );
 
-  return { form, errors, updateField, handleSaIdChange, handleSubmit, saIdHelperText };
+  return { form, errors, isDirty, updateField, handleSaIdChange, handleSubmit, saIdHelperText };
 }


### PR DESCRIPTION
## Summary
- Unsaved changes detection with discard confirmation dialog on back navigation
- Success feedback alert after saving profile changes
- Cancel button on both create and edit profile screens
- Reusable `ScreenHeader` component extracted from profile screens
- `isDirty` tracking via JSON snapshot comparison in `useProfileForm` hook

Closes #33

## Test plan
- [ ] Edit a profile field, press back — should see "Discard Changes?" dialog
- [ ] Press "Keep Editing" — stays on form
- [ ] Press "Discard" — navigates back without saving
- [ ] Save changes — should see "Profile Updated" success alert
- [ ] Create new profile — should see "Profile Created" success alert
- [ ] Press Cancel button — navigates back (with discard warning if dirty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)