### PR TITLE
feat(mobile): add dependent profile management (S-36)

### DIFF
--- a/apps/mobile/app/(tabs)/profiles.tsx
+++ b/apps/mobile/app/(tabs)/profiles.tsx
@@ -13,6 +13,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { useTheme } from '../../src/theme';
 import { Card, Button } from '../../src/components/ui';
 import { ProfileCard } from '../../src/components/profile/ProfileCard';
+import { DependentList } from '../../src/components/profile/DependentList';
 import type { UserProfile } from '@fillit/shared';
 import {
   useProfileStore,
@@ -222,6 +223,7 @@ export default function ProfilesScreen() {
         iconLeft={<Ionicons name="create-outline" size={18} color={theme.colors.primary} />}
         testID="edit-profile-button"
       />
+      <DependentList />
     </ScrollView>
   );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -36,6 +36,8 @@ function RootNavigator() {
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="profile/create" options={{ headerShown: false }} />
       <Stack.Screen name="profile/edit" options={{ headerShown: false }} />
+      <Stack.Screen name="profile/dependent/add" options={{ headerShown: false }} />
+      <Stack.Screen name="profile/dependent/[id]" options={{ headerShown: false }} />
       <Stack.Screen name="__e2e" options={{ headerShown: true, headerTitle: 'E2E Tests' }} />
     </Stack>
   );

--- a/apps/mobile/app/profile/dependent/RelationshipSection.tsx
+++ b/apps/mobile/app/profile/dependent/RelationshipSection.tsx
@@ -1,0 +1,48 @@
+/**
+ * Relationship picker section for dependent profile screens.
+ *
+ * Renders a Card with an OptionPicker for selecting the dependent's
+ * relationship to the primary profile holder.
+ */
+
+import { View, Text } from 'react-native';
+import type { ProfileRelationship } from '@fillit/shared';
+
+import { useTheme } from '../../../src/theme';
+import { Card } from '../../../src/components/ui';
+import { SectionHeader, OptionPicker } from '../../../src/components/profile/ProfileFormSections';
+import { RELATIONSHIP_OPTIONS } from '../../../src/components/profile/profileFormTypes';
+
+interface RelationshipSectionProps {
+  readonly value: ProfileRelationship | '';
+  readonly onChange: (value: ProfileRelationship | '') => void;
+  readonly error?: string;
+}
+
+export function RelationshipSection({ value, onChange, error }: RelationshipSectionProps) {
+  const { theme } = useTheme();
+
+  return (
+    <Card style={{ marginBottom: theme.spacing.lg }}>
+      <SectionHeader icon="people-outline" title="Relationship" />
+      <OptionPicker
+        label="Relationship to you"
+        options={RELATIONSHIP_OPTIONS}
+        value={value}
+        onChange={onChange}
+      />
+      {error ? (
+        <View style={{ marginTop: -theme.spacing.sm }}>
+          <Text
+            style={[theme.typography.caption, { color: theme.colors.error }]}
+            testID="relationship-error"
+          >
+            {error}
+          </Text>
+        </View>
+      ) : null}
+    </Card>
+  );
+}
+
+RelationshipSection.displayName = 'RelationshipSection';

--- a/apps/mobile/app/profile/dependent/[id].tsx
+++ b/apps/mobile/app/profile/dependent/[id].tsx
@@ -1,0 +1,99 @@
+/**
+ * Edit dependent profile screen.
+ *
+ * Pre-fills the ProfileForm with the dependent's existing data,
+ * includes a relationship picker, and provides a delete option
+ * with confirmation dialog.
+ */
+
+import { View, Text, StyleSheet } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+import { useTheme } from '../../../src/theme';
+import { Button } from '../../../src/components/ui';
+import { ProfileForm } from '../../../src/components/profile';
+import { ScreenHeader } from '../../../src/components/profile/ScreenHeader';
+import { useProfileStore, selectProfileById } from '../../../src/stores/profile-store';
+import { RelationshipSection } from './RelationshipSection';
+import { useEditDependent } from './useEditDependent';
+
+// ─── Screen ─────────────────────────────────────────────────────────
+
+export default function EditDependentScreen() {
+  const { theme } = useTheme();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const profile = useProfileStore(selectProfileById(id ?? ''));
+  const {
+    relationship,
+    isMutating,
+    handleDirtyChange,
+    handleBack,
+    handleSubmit,
+    handleDelete,
+    handleRelationshipChange,
+  } = useEditDependent(profile);
+
+  if (!profile) {
+    return (
+      <View style={[styles.container, styles.center, { backgroundColor: theme.colors.background }]}>
+        <Text style={[theme.typography.bodyLarge, { color: theme.colors.onSurfaceVariant }]}>
+          Dependent not found
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      testID="edit-dependent-screen"
+    >
+      <ScreenHeader title="Edit Dependent" onBack={handleBack} />
+      <ProfileForm
+        initialData={profile}
+        onSubmit={handleSubmit}
+        onCancel={handleBack}
+        onDirtyChange={handleDirtyChange}
+        isSaving={isMutating}
+        headerContent={
+          <RelationshipSection value={relationship} onChange={handleRelationshipChange} />
+        }
+      />
+      <DeleteButton onDelete={handleDelete} isDeleting={isMutating} />
+    </View>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────
+
+function DeleteButton({ onDelete, isDeleting }: { onDelete: () => void; isDeleting: boolean }) {
+  const { theme } = useTheme();
+  return (
+    <View
+      style={{
+        paddingHorizontal: theme.spacing.lg,
+        paddingBottom: theme.spacing.xl,
+      }}
+    >
+      <Button
+        label={isDeleting ? 'Deleting...' : 'Delete Dependent'}
+        variant="ghost"
+        onPress={onDelete}
+        fullWidth
+        size="md"
+        style={{ borderColor: theme.colors.error }}
+        testID="delete-dependent-button"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  center: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/apps/mobile/app/profile/dependent/add.tsx
+++ b/apps/mobile/app/profile/dependent/add.tsx
@@ -1,0 +1,84 @@
+/**
+ * Add dependent profile screen.
+ *
+ * Presents a relationship picker followed by the reusable ProfileForm.
+ * Creates a new profile with isPrimary=false and the selected relationship.
+ */
+
+import { useState, useCallback } from 'react';
+import { View, StyleSheet, Alert } from 'react-native';
+import { router } from 'expo-router';
+import type { ProfileRelationship } from '@fillit/shared';
+
+import { useTheme } from '../../../src/theme';
+import { ProfileForm } from '../../../src/components/profile';
+import { ScreenHeader } from '../../../src/components/profile/ScreenHeader';
+import { useProfileStore } from '../../../src/stores/profile-store';
+import type { CreateProfileInput } from '../../../src/services/storage/profileCrud';
+import { RelationshipSection } from './RelationshipSection';
+
+export default function AddDependentScreen() {
+  const { theme } = useTheme();
+  const createProfile = useProfileStore((s) => s.createProfile);
+  const isMutating = useProfileStore((s) => s.mutationCount > 0);
+  const [relationship, setRelationship] = useState<ProfileRelationship | ''>('');
+  const [relationshipError, setRelationshipError] = useState('');
+
+  const handleSubmit = useCallback(
+    async (data: CreateProfileInput) => {
+      if (!relationship) {
+        setRelationshipError('Please select a relationship');
+        return;
+      }
+      try {
+        const input: CreateProfileInput = {
+          ...data,
+          isPrimary: false,
+          relationship,
+        };
+        await createProfile(input);
+        Alert.alert('Dependent Added', 'The dependent profile has been created.', [
+          { text: 'OK', onPress: () => router.back() },
+        ]);
+      } catch (err) {
+        Alert.alert(
+          'Error',
+          err instanceof Error ? err.message : 'Failed to add dependent. Please try again.',
+        );
+      }
+    },
+    [createProfile, relationship],
+  );
+
+  const handleRelationshipChange = useCallback((val: ProfileRelationship | '') => {
+    setRelationship(val);
+    if (val) setRelationshipError('');
+  }, []);
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      testID="add-dependent-screen"
+    >
+      <ScreenHeader title="Add Dependent" onBack={() => router.back()} />
+      <ProfileForm
+        onSubmit={handleSubmit}
+        onCancel={() => router.back()}
+        isSaving={isMutating}
+        headerContent={
+          <RelationshipSection
+            value={relationship}
+            onChange={handleRelationshipChange}
+            error={relationshipError}
+          />
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/apps/mobile/app/profile/dependent/useEditDependent.ts
+++ b/apps/mobile/app/profile/dependent/useEditDependent.ts
@@ -1,0 +1,116 @@
+/**
+ * Custom hook for the edit dependent screen logic.
+ *
+ * Encapsulates state management, submit/delete handlers,
+ * and relationship tracking for the edit dependent flow.
+ */
+
+import { useState, useCallback, useRef } from 'react';
+import { Alert } from 'react-native';
+import { router } from 'expo-router';
+import type { ProfileRelationship, UserProfile } from '@fillit/shared';
+
+import { useProfileStore } from '../../../src/stores/profile-store';
+import type { CreateProfileInput } from '../../../src/services/storage/profileCrud';
+
+// ─── Confirmation dialogs ───────────────────────────────────────────
+
+function confirmDiscard(): Promise<boolean> {
+  return new Promise((resolve) => {
+    Alert.alert('Discard Changes?', 'You have unsaved changes. Are you sure you want to go back?', [
+      { text: 'Keep Editing', style: 'cancel', onPress: () => resolve(false) },
+      { text: 'Discard', style: 'destructive', onPress: () => resolve(true) },
+    ]);
+  });
+}
+
+function confirmDelete(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    Alert.alert(
+      'Delete Dependent?',
+      `Are you sure you want to delete ${name}? This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+        { text: 'Delete', style: 'destructive', onPress: () => resolve(true) },
+      ],
+    );
+  });
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────
+
+export function useEditDependent(profile: UserProfile | null) {
+  const updateProfile = useProfileStore((s) => s.updateProfile);
+  const deleteProfile = useProfileStore((s) => s.deleteProfile);
+  const isMutating = useProfileStore((s) => s.mutationCount > 0);
+  const isDirtyRef = useRef(false);
+
+  const [relationship, setRelationship] = useState<ProfileRelationship | ''>(
+    profile?.relationship ?? '',
+  );
+
+  const handleDirtyChange = useCallback((dirty: boolean) => {
+    isDirtyRef.current = dirty;
+  }, []);
+
+  const handleBack = useCallback(async () => {
+    if (isDirtyRef.current) {
+      const shouldDiscard = await confirmDiscard();
+      if (!shouldDiscard) return;
+    }
+    router.back();
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (data: CreateProfileInput) => {
+      if (!profile) return;
+      if (!relationship) {
+        Alert.alert('Error', 'Please select a relationship');
+        return;
+      }
+      try {
+        await updateProfile(profile.id, { ...data, isPrimary: false, relationship });
+        Alert.alert('Dependent Updated', 'The dependent profile has been saved.', [
+          { text: 'OK', onPress: () => router.back() },
+        ]);
+      } catch (err) {
+        Alert.alert(
+          'Error',
+          err instanceof Error ? err.message : 'Failed to update dependent. Please try again.',
+        );
+      }
+    },
+    [profile, updateProfile, relationship],
+  );
+
+  const handleDelete = useCallback(async () => {
+    if (!profile) return;
+    const fullName = `${profile.firstName} ${profile.lastName}`;
+    const shouldDelete = await confirmDelete(fullName);
+    if (!shouldDelete) return;
+    try {
+      await deleteProfile(profile.id);
+      router.back();
+    } catch (err) {
+      Alert.alert(
+        'Error',
+        err instanceof Error ? err.message : 'Failed to delete dependent. Please try again.',
+      );
+    }
+  }, [profile, deleteProfile]);
+
+  const handleRelationshipChange = useCallback((val: ProfileRelationship | '') => {
+    setRelationship(val);
+    isDirtyRef.current = true;
+  }, []);
+
+  return {
+    relationship,
+    isMutating,
+    handleDirtyChange,
+    handleBack,
+    handleSubmit,
+    handleDelete,
+    handleRelationshipChange,
+  };
+}

--- a/apps/mobile/src/components/profile/DependentCard.tsx
+++ b/apps/mobile/src/components/profile/DependentCard.tsx
@@ -1,0 +1,152 @@
+/**
+ * Card component for a single dependent profile.
+ *
+ * Displays the dependent's name, relationship badge, completeness
+ * percentage, and an active indicator. Supports tap to edit and
+ * a "Set Active" button.
+ */
+
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import type { UserProfile, ProfileRelationship } from '@fillit/shared';
+
+import { useTheme } from '../../theme';
+import { Card, Avatar, Chip } from '../ui';
+
+interface DependentCardProps {
+  readonly profile: UserProfile;
+  readonly completeness: number;
+  readonly isActive: boolean;
+  readonly onPress: () => void;
+  readonly onSetActive: () => void;
+}
+
+const RELATIONSHIP_LABELS: Record<ProfileRelationship, string> = {
+  spouse: 'Spouse',
+  child: 'Child',
+  parent: 'Parent',
+  other: 'Other',
+};
+
+function getRelationshipLabel(rel?: ProfileRelationship): string {
+  return rel ? RELATIONSHIP_LABELS[rel] : 'Unknown';
+}
+
+export function DependentCard({
+  profile,
+  completeness,
+  isActive,
+  onPress,
+  onSetActive,
+}: DependentCardProps) {
+  const { theme } = useTheme();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Edit ${profile.firstName} ${profile.lastName}`}
+      testID={`dependent-card-${profile.id}`}
+    >
+      <Card style={{ marginBottom: theme.spacing.md }}>
+        <CardHeader profile={profile} isActive={isActive} />
+        <CardFooter completeness={completeness} isActive={isActive} onSetActive={onSetActive} />
+      </Card>
+    </Pressable>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────
+
+function CardHeader({ profile, isActive }: { profile: UserProfile; isActive: boolean }) {
+  const { theme } = useTheme();
+  const fullName = `${profile.firstName} ${profile.lastName}`;
+  const relLabel = getRelationshipLabel(profile.relationship);
+
+  return (
+    <View style={styles.headerRow}>
+      <Avatar name={fullName} size="md" />
+      <View style={[styles.headerInfo, { marginLeft: theme.spacing.md }]}>
+        <View style={styles.nameRow}>
+          <Text
+            style={[theme.typography.titleMedium, { color: theme.colors.onSurface, flex: 1 }]}
+            numberOfLines={1}
+          >
+            {fullName}
+          </Text>
+          {isActive ? (
+            <Ionicons
+              name="checkmark-circle"
+              size={20}
+              color={theme.colors.success}
+              style={{ marginLeft: theme.spacing.xs }}
+            />
+          ) : null}
+        </View>
+        <View style={[styles.chipRow, { marginTop: theme.spacing.xs }]}>
+          <Chip label={relLabel} color="primary" />
+        </View>
+      </View>
+      <Ionicons name="chevron-forward" size={20} color={theme.colors.onSurfaceVariant} />
+    </View>
+  );
+}
+
+function CardFooter({
+  completeness,
+  isActive,
+  onSetActive,
+}: {
+  completeness: number;
+  isActive: boolean;
+  onSetActive: () => void;
+}) {
+  const { theme } = useTheme();
+
+  return (
+    <View style={[styles.footerRow, { marginTop: theme.spacing.md }]}>
+      <Text style={[theme.typography.caption, { color: theme.colors.onSurfaceVariant, flex: 1 }]}>
+        {completeness}% complete
+      </Text>
+      {!isActive ? (
+        <Pressable
+          onPress={onSetActive}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Set as active profile"
+          testID="set-active-button"
+        >
+          <Text style={[theme.typography.labelMedium, { color: theme.colors.primary }]}>
+            Set Active
+          </Text>
+        </Pressable>
+      ) : (
+        <Text style={[theme.typography.labelMedium, { color: theme.colors.success }]}>Active</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  headerInfo: {
+    flex: 1,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  footerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+
+DependentCard.displayName = 'DependentCard';

--- a/apps/mobile/src/components/profile/DependentList.tsx
+++ b/apps/mobile/src/components/profile/DependentList.tsx
@@ -1,0 +1,184 @@
+/**
+ * List of dependent profiles displayed as cards.
+ *
+ * Shows each dependent's name, relationship badge, and profile
+ * completeness. Includes an "Add Dependent" button and supports
+ * setting a dependent as the active profile.
+ */
+
+import { useCallback } from 'react';
+import { View, Text, StyleSheet, Alert } from 'react-native';
+import { router } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import type { UserProfile } from '@fillit/shared';
+
+import { useTheme } from '../../theme';
+import { Button } from '../ui';
+import { DependentCard } from './DependentCard';
+import {
+  useProfileStore,
+  selectDependentProfiles,
+  selectActiveProfileId,
+} from '../../stores/profile-store';
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+const COMPLETENESS_FIELDS = [
+  'firstName',
+  'lastName',
+  'email',
+  'phoneMobile',
+  'dateOfBirth',
+  'saIdNumber',
+  'gender',
+  'employer',
+  'nationality',
+  'citizenship',
+] as const;
+
+function calcCompleteness(profile: UserProfile): number {
+  const filled = COMPLETENESS_FIELDS.filter((f) => {
+    const v = profile[f as keyof UserProfile];
+    return typeof v === 'string' && v.trim().length > 0;
+  }).length;
+  return Math.round((filled / COMPLETENESS_FIELDS.length) * 100);
+}
+
+// ─── Component ──────────────────────────────────────────────────────
+
+export function DependentList() {
+  const { theme } = useTheme();
+  const dependents = useProfileStore(selectDependentProfiles);
+  const activeProfileId = useProfileStore(selectActiveProfileId);
+  const setActiveProfileId = useProfileStore((s) => s.setActiveProfileId);
+
+  const handleAddDependent = useCallback(() => {
+    router.push('/profile/dependent/add');
+  }, []);
+
+  const handleEditDependent = useCallback((id: string) => {
+    router.push(`/profile/dependent/${id}`);
+  }, []);
+
+  const handleSetActive = useCallback(
+    (profile: UserProfile) => {
+      setActiveProfileId(profile.id);
+      Alert.alert(
+        'Active Profile Changed',
+        `${profile.firstName} ${profile.lastName} is now the active profile for form filling.`,
+      );
+    },
+    [setActiveProfileId],
+  );
+
+  if (dependents.length === 0) {
+    return (
+      <View style={{ marginTop: theme.spacing.xl }}>
+        <DependentSectionHeader />
+        <EmptyDependents onAdd={handleAddDependent} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ marginTop: theme.spacing.xl }} testID="dependent-list">
+      <DependentSectionHeader />
+      {dependents.map((dep) => (
+        <DependentCard
+          key={dep.id}
+          profile={dep}
+          completeness={calcCompleteness(dep)}
+          isActive={dep.id === activeProfileId}
+          onPress={() => handleEditDependent(dep.id)}
+          onSetActive={() => handleSetActive(dep)}
+        />
+      ))}
+      <Button
+        label="Add Dependent"
+        variant="outline"
+        onPress={handleAddDependent}
+        fullWidth
+        iconLeft={<Ionicons name="person-add-outline" size={18} color={theme.colors.primary} />}
+        testID="add-dependent-button"
+      />
+    </View>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────
+
+function DependentSectionHeader() {
+  const { theme } = useTheme();
+  return (
+    <View style={[styles.sectionHeader, { marginBottom: theme.spacing.md }]}>
+      <Ionicons name="people-outline" size={22} color={theme.colors.primary} />
+      <Text
+        style={[
+          theme.typography.titleLarge,
+          {
+            color: theme.colors.onSurface,
+            marginLeft: theme.spacing.sm,
+            flex: 1,
+          },
+        ]}
+      >
+        Dependents
+      </Text>
+    </View>
+  );
+}
+
+function EmptyDependents({ onAdd }: { onAdd: () => void }) {
+  const { theme } = useTheme();
+  return (
+    <View
+      style={[
+        styles.emptyState,
+        {
+          backgroundColor: theme.colors.surfaceVariant,
+          borderRadius: theme.radii.lg,
+          padding: theme.spacing.xl,
+          marginBottom: theme.spacing.lg,
+        },
+      ]}
+    >
+      <Ionicons
+        name="people-outline"
+        size={40}
+        color={theme.colors.onSurfaceVariant}
+        style={{ marginBottom: theme.spacing.sm }}
+      />
+      <Text
+        style={[
+          theme.typography.bodyMedium,
+          {
+            color: theme.colors.onSurfaceVariant,
+            textAlign: 'center',
+          },
+        ]}
+      >
+        No dependents added yet. Add family members to auto-fill forms for them too.
+      </Text>
+      <View style={{ marginTop: theme.spacing.md }}>
+        <Button
+          label="Add Dependent"
+          onPress={onAdd}
+          size="md"
+          testID="add-first-dependent-button"
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  emptyState: {
+    alignItems: 'center',
+  },
+});
+
+DependentList.displayName = 'DependentList';

--- a/apps/mobile/src/components/profile/ProfileForm.tsx
+++ b/apps/mobile/src/components/profile/ProfileForm.tsx
@@ -27,6 +27,8 @@ export interface ProfileFormProps {
   readonly onCancel?: () => void;
   readonly onDirtyChange?: (isDirty: boolean) => void;
   readonly isSaving?: boolean;
+  /** Optional content rendered above the form sections (e.g. relationship picker). */
+  readonly headerContent?: React.ReactNode;
 }
 
 export function ProfileForm({
@@ -35,6 +37,7 @@ export function ProfileForm({
   onCancel,
   onDirtyChange,
   isSaving = false,
+  headerContent,
 }: ProfileFormProps) {
   const { theme } = useTheme();
   const isEditing = Boolean(initialData);
@@ -57,6 +60,7 @@ export function ProfileForm({
         keyboardShouldPersistTaps="handled"
         testID="profile-form-scroll"
       >
+        {headerContent}
         <SaIdSection
           form={form}
           errors={errors}

--- a/apps/mobile/src/components/profile/index.ts
+++ b/apps/mobile/src/components/profile/index.ts
@@ -1,3 +1,5 @@
 export { ProfileForm } from './ProfileForm';
 export type { ProfileFormProps } from './ProfileForm';
 export { ProfileCard } from './ProfileCard';
+export { DependentCard } from './DependentCard';
+export { DependentList } from './DependentList';

--- a/apps/mobile/src/components/profile/profileFormTypes.ts
+++ b/apps/mobile/src/components/profile/profileFormTypes.ts
@@ -8,6 +8,7 @@ import {
   type Gender,
   type MaritalStatus,
   type Citizenship,
+  type ProfileRelationship,
   type UserProfile,
 } from '@fillit/shared';
 
@@ -62,6 +63,13 @@ export const MARITAL_OPTIONS: { label: string; value: MaritalStatus }[] = [
 export const CITIZENSHIP_OPTIONS: { label: string; value: Citizenship }[] = [
   { label: 'SA Citizen', value: 'citizen' },
   { label: 'Permanent Resident', value: 'permanent_resident' },
+];
+
+export const RELATIONSHIP_OPTIONS: { label: string; value: ProfileRelationship }[] = [
+  { label: 'Spouse', value: 'spouse' },
+  { label: 'Child', value: 'child' },
+  { label: 'Parent', value: 'parent' },
+  { label: 'Other', value: 'other' },
 ];
 
 const EMPTY_FORM: ProfileFormData = {
@@ -137,13 +145,20 @@ function optionalString<K extends string>(key: K, value: string): Record<K, stri
   return trimmed ? ({ [key]: trimmed } as Record<K, string>) : undefined;
 }
 
+/** Optional overrides for dependent profile creation. */
+export interface BuildProfileOverrides {
+  isPrimary?: boolean;
+  relationship?: ProfileRelationship;
+}
+
 export function buildProfileInput(
   form: ProfileFormData,
   initialData?: UserProfile,
+  overrides?: BuildProfileOverrides,
 ): CreateProfileInput {
   return {
     id: initialData?.id ?? crypto.randomUUID(),
-    isPrimary: initialData?.isPrimary ?? true,
+    isPrimary: overrides?.isPrimary ?? initialData?.isPrimary ?? true,
     firstName: form.firstName.trim(),
     lastName: form.lastName.trim(),
     dateOfBirth: form.dateOfBirth || '',
@@ -160,6 +175,7 @@ export function buildProfileInput(
     ...(form.gender ? { gender: form.gender as Gender } : undefined),
     ...(form.maritalStatus ? { maritalStatus: form.maritalStatus as MaritalStatus } : undefined),
     ...(form.citizenship ? { citizenship: form.citizenship as Citizenship } : undefined),
+    ...(overrides?.relationship ? { relationship: overrides.relationship } : undefined),
   };
 }
 


### PR DESCRIPTION
## Summary

- Add dependent profile CRUD (add, edit, delete) with relationship picker (spouse/child/parent/other)
- Display dependent profiles in a dedicated section on the Profiles tab with completeness indicators and relationship badges
- Support switching active profile for form filling via "Set Active" button on dependent cards
- Reuse existing ProfileForm with new `headerContent` prop for relationship section injection

Closes #37

## Test plan

- [ ] Add a dependent profile with each relationship type (spouse, child, parent, other)
- [ ] Edit a dependent profile and verify changes persist
- [ ] Delete a dependent profile and confirm the deletion dialog appears
- [ ] Verify the relationship picker is required when creating/editing dependents
- [ ] Set a dependent as the active profile and confirm the active indicator updates
- [ ] Verify the primary profile still shows correctly on the Profiles tab
- [ ] Confirm empty state appears when no dependents exist
- [ ] Verify unsaved changes trigger discard confirmation on back navigation
- [ ] Run existing tests to confirm no regressions

Generated with [Claude Code](https://claude.com/claude-code)