### PR TITLE
feat(mobile): home dashboard with scan FAB and recent documents (S-38)

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -1,165 +1,175 @@
 /**
  * Home / Dashboard tab screen.
  *
- * Displays a welcome message, quick-action buttons (Scan, Import),
- * recent documents, and a profile completeness indicator.
+ * Displays a welcome greeting, quick-action buttons (Scan, Import),
+ * quick stats, recent documents, and a floating scan FAB.
  * This is the primary landing screen after app launch.
  */
 
-import { StyleSheet, Text, View, Pressable, ScrollView } from 'react-native';
+import React, { useEffect } from 'react';
+import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { useTheme } from '../../src/theme';
+import { Button, DisplayMedium, BodyLarge } from '../../src/components/ui';
+import { ScanFAB, QuickStats, RecentDocuments } from '../../src/components/home';
+import {
+  useDocumentStore,
+  selectDocuments,
+  selectIsLoading as selectDocIsLoading,
+  selectIsInitialized as selectDocIsInitialized,
+  selectDocumentsByStatus,
+} from '../../src/stores/document-store';
+import {
+  useProfileStore,
+  selectProfileCount,
+  selectIsInitialized as selectProfileIsInitialized,
+} from '../../src/stores/profile-store';
 
 export default function HomeScreen() {
+  useStoreInitialization();
+
+  return (
+    <View style={styles.root} testID="home-screen">
+      <DashboardContent />
+      <ScanFAB />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/** Initialize document and profile stores on mount */
+function useStoreInitialization() {
+  const initDocs = useDocumentStore((s) => s.initialize);
+  const initProfiles = useProfileStore((s) => s.initialize);
+
+  useEffect(() => {
+    void initDocs();
+    void initProfiles();
+  }, [initDocs, initProfiles]);
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+/** Scrollable dashboard body with hero, actions, stats, and documents */
+function DashboardContent() {
   const { theme } = useTheme();
+  const documents = useDocumentStore(selectDocuments);
+  const isLoading = useDocumentStore(selectDocIsLoading);
+  const docInitialized = useDocumentStore(selectDocIsInitialized);
+  const profileInitialized = useProfileStore(selectProfileIsInitialized);
+  const profileCount = useProfileStore(selectProfileCount);
+  const exportedCount = useDocumentStore(selectDocumentsByStatus('exported')).length;
+
+  const sortedDocs = [...documents].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  const storesReady = docInitialized && profileInitialized;
 
   return (
     <ScrollView
-      style={[styles.screen, { backgroundColor: theme.colors.background }]}
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
       contentContainerStyle={[styles.content, { padding: theme.spacing.lg }]}
-      testID="home-screen"
     >
-      {/* Hero section */}
-      <View style={[styles.hero, { marginBottom: theme.spacing['2xl'] }]}>
-        <Text
-          style={[
-            theme.typography.displayMedium,
-            { color: theme.colors.onBackground, marginBottom: theme.spacing.xs },
-          ]}
-        >
-          FillIt
-        </Text>
-        <Text
-          style={[
-            theme.typography.bodyLarge,
-            { color: theme.colors.onSurfaceVariant, textAlign: 'center' },
-          ]}
-        >
-          Scan, fill, and export documents with ease.
-        </Text>
-      </View>
+      <HeroSection />
+      <QuickActions />
 
-      {/* Quick actions */}
-      <View style={[styles.quickActions, { gap: theme.spacing.md }]}>
-        <Pressable
-          style={({ pressed }) => [
-            styles.actionButton,
-            {
-              backgroundColor: theme.colors.primary,
-              borderRadius: theme.radii.lg,
-              padding: theme.spacing.lg,
-              ...theme.elevations.md,
-            },
-            pressed && styles.pressed,
-          ]}
-          accessibilityRole="button"
-          accessibilityLabel="Scan a document"
-          testID="action-scan"
-        >
-          <Ionicons name="scan" size={32} color={theme.colors.onPrimary} />
-          <Text
-            style={[
-              theme.typography.titleLarge,
-              { color: theme.colors.onPrimary, marginTop: theme.spacing.sm },
-            ]}
-          >
-            Scan
-          </Text>
-          <Text
-            style={[theme.typography.bodySmall, { color: theme.colors.onPrimary, opacity: 0.9 }]}
-          >
-            Use camera to scan
-          </Text>
-        </Pressable>
-
-        <Pressable
-          style={({ pressed }) => [
-            styles.actionButton,
-            {
-              backgroundColor: theme.colors.surface,
-              borderRadius: theme.radii.lg,
-              borderWidth: 1,
-              borderColor: theme.colors.outline,
-              padding: theme.spacing.lg,
-              ...theme.elevations.sm,
-            },
-            pressed && styles.pressed,
-          ]}
-          accessibilityRole="button"
-          accessibilityLabel="Import a document"
-          testID="action-import"
-        >
-          <Ionicons name="document-attach-outline" size={32} color={theme.colors.primary} />
-          <Text
-            style={[
-              theme.typography.titleLarge,
-              { color: theme.colors.onSurface, marginTop: theme.spacing.sm },
-            ]}
-          >
-            Import
-          </Text>
-          <Text style={[theme.typography.bodySmall, { color: theme.colors.onSurfaceVariant }]}>
-            PDF or image file
-          </Text>
-        </Pressable>
-      </View>
-
-      {/* Recent documents placeholder */}
-      <View style={{ marginTop: theme.spacing['3xl'] }}>
-        <Text
-          style={[
-            theme.typography.headlineMedium,
-            { color: theme.colors.onBackground, marginBottom: theme.spacing.md },
-          ]}
-        >
-          Recent Documents
-        </Text>
-        <View
-          style={[
-            styles.emptyState,
-            {
-              backgroundColor: theme.colors.surfaceVariant,
-              borderRadius: theme.radii.lg,
-              padding: theme.spacing['2xl'],
-            },
-          ]}
-          testID="empty-recent-documents"
-        >
-          <Ionicons
-            name="documents-outline"
-            size={48}
-            color={theme.colors.onSurfaceVariant}
-            style={{ marginBottom: theme.spacing.md }}
+      {storesReady ? (
+        <>
+          <QuickStats
+            documentCount={documents.length}
+            profileCount={profileCount}
+            exportedCount={exportedCount}
           />
-          <Text
-            style={[
-              theme.typography.bodyLarge,
-              { color: theme.colors.onSurfaceVariant, textAlign: 'center' },
-            ]}
-          >
-            No documents yet
-          </Text>
-          <Text
-            style={[
-              theme.typography.bodySmall,
-              {
-                color: theme.colors.onSurfaceVariant,
-                textAlign: 'center',
-                marginTop: theme.spacing.xs,
-              },
-            ]}
-          >
-            Scan or import your first document to get started.
-          </Text>
-        </View>
-      </View>
+          <RecentDocuments documents={sortedDocs} isLoading={isLoading} />
+        </>
+      ) : (
+        <>
+          <QuickStats documentCount={0} profileCount={0} exportedCount={0} />
+          <RecentDocuments documents={[]} isLoading />
+        </>
+      )}
+
+      {/* Bottom spacer for FAB clearance */}
+      <View style={{ height: 100 }} />
     </ScrollView>
   );
 }
 
+DashboardContent.displayName = 'DashboardContent';
+
+/** Welcome hero banner */
+function HeroSection() {
+  const { theme } = useTheme();
+
+  return (
+    <View style={[styles.hero, { marginBottom: theme.spacing['2xl'] }]}>
+      <DisplayMedium>FillIt</DisplayMedium>
+      <BodyLarge color="secondary" align="center">
+        Scan, fill, and export documents with ease.
+      </BodyLarge>
+    </View>
+  );
+}
+
+HeroSection.displayName = 'HeroSection';
+
+/** Scan and Import action buttons */
+function QuickActions() {
+  const { theme } = useTheme();
+
+  const handleScan = () => {
+    Alert.alert('Coming Soon', 'Document scanning will be available in a future update.');
+  };
+
+  const handleImport = () => {
+    Alert.alert('Coming Soon', 'Document import will be available in a future update.');
+  };
+
+  return (
+    <View style={[styles.quickActions, { gap: theme.spacing.md, marginBottom: theme.spacing.xl }]}>
+      <Button
+        label="Scan"
+        variant="primary"
+        size="lg"
+        fullWidth
+        onPress={handleScan}
+        iconLeft={<Ionicons name="scan" size={22} color={theme.colors.onPrimary} />}
+        accessibilityLabel="Scan a document"
+        testID="action-scan"
+        style={{ flex: 1 }}
+      />
+      <Button
+        label="Import"
+        variant="outline"
+        size="lg"
+        fullWidth
+        onPress={handleImport}
+        iconLeft={
+          <Ionicons name="document-attach-outline" size={22} color={theme.colors.primary} />
+        }
+        accessibilityLabel="Import a document"
+        testID="action-import"
+        style={{ flex: 1 }}
+      />
+    </View>
+  );
+}
+
+QuickActions.displayName = 'QuickActions';
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
 const styles = StyleSheet.create({
-  screen: {
+  root: {
     flex: 1,
   },
   content: {
@@ -171,17 +181,5 @@ const styles = StyleSheet.create({
   },
   quickActions: {
     flexDirection: 'row',
-  },
-  actionButton: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  pressed: {
-    opacity: 0.8,
-    transform: [{ scale: 0.98 }],
-  },
-  emptyState: {
-    alignItems: 'center',
   },
 });

--- a/apps/mobile/src/components/home/DocumentCard.tsx
+++ b/apps/mobile/src/components/home/DocumentCard.tsx
@@ -1,0 +1,92 @@
+/**
+ * Individual document card for the recent documents list.
+ *
+ * Shows the document title, creation date, page count, and a
+ * status chip. Pressable to navigate to the document detail.
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { ProcessedDocument } from '@fillit/shared';
+
+import { useTheme } from '../../theme';
+import { BodySmall, TitleMedium, PressableCard, Chip } from '../ui';
+
+import { formatStatus, getStatusChipColor } from './RecentDocuments';
+
+/** Props for the DocumentCard component */
+export interface DocumentCardProps {
+  /** The document to render */
+  readonly document: ProcessedDocument;
+  /** Called when the card is pressed */
+  readonly onPress?: (id: string) => void;
+}
+
+/** Format an ISO date string for display */
+function formatDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return date.toLocaleDateString('en-ZA', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Pressable card displaying a single document summary.
+ *
+ * @example
+ * ```tsx
+ * <DocumentCard
+ *   document={doc}
+ *   onPress={(id) => router.push(`/document/${id}`)}
+ * />
+ * ```
+ */
+export function DocumentCard({ document, onPress }: DocumentCardProps) {
+  const { theme } = useTheme();
+  const pageCount = document.pages.length;
+
+  return (
+    <PressableCard
+      elevation="sm"
+      padding="lg"
+      onPress={() => onPress?.(document.id)}
+      accessibilityLabel={`Document: ${document.title}`}
+      testID={`document-card-${document.id}`}
+    >
+      <TitleMedium numberOfLines={1}>{document.title}</TitleMedium>
+
+      <View style={[styles.footer, { marginTop: theme.spacing.sm }]}>
+        <View style={styles.meta}>
+          <BodySmall color="secondary">{formatDate(document.createdAt)}</BodySmall>
+          <BodySmall color="secondary">
+            {' \u00B7 '}
+            {pageCount} {pageCount === 1 ? 'page' : 'pages'}
+          </BodySmall>
+        </View>
+
+        <Chip
+          label={formatStatus(document.status)}
+          color={getStatusChipColor(document.status)}
+          variant="filled"
+        />
+      </View>
+    </PressableCard>
+  );
+}
+
+DocumentCard.displayName = 'DocumentCard';
+
+const styles = StyleSheet.create({
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  meta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexShrink: 1,
+  },
+});

--- a/apps/mobile/src/components/home/EmptyDashboard.tsx
+++ b/apps/mobile/src/components/home/EmptyDashboard.tsx
@@ -1,0 +1,60 @@
+/**
+ * Empty state shown on the home dashboard when the user has
+ * no documents yet. Displays an illustration icon and guidance
+ * text encouraging the user to scan or import their first document.
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../theme';
+import { BodyLarge, BodySmall } from '../ui';
+
+/**
+ * Empty dashboard state for new users.
+ *
+ * @example
+ * ```tsx
+ * {documents.length === 0 && <EmptyDashboard />}
+ * ```
+ */
+export function EmptyDashboard() {
+  const { theme } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: theme.colors.surfaceVariant,
+          borderRadius: theme.radii.lg,
+          padding: theme.spacing['2xl'],
+        },
+      ]}
+      testID="empty-dashboard"
+    >
+      <Ionicons
+        name="documents-outline"
+        size={64}
+        color={theme.colors.onSurfaceVariant}
+        style={{ marginBottom: theme.spacing.md }}
+      />
+      <BodyLarge color="secondary" align="center">
+        No documents yet
+      </BodyLarge>
+      <BodySmall color="secondary" align="center" style={{ marginTop: theme.spacing.xs }}>
+        Scan or import your first document to get started.
+      </BodySmall>
+    </View>
+  );
+}
+
+EmptyDashboard.displayName = 'EmptyDashboard';
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/src/components/home/QuickStats.tsx
+++ b/apps/mobile/src/components/home/QuickStats.tsx
@@ -1,0 +1,87 @@
+/**
+ * Quick stats row for the home dashboard.
+ *
+ * Shows a horizontal row of stat cards with totals for documents
+ * processed, profiles created, and documents exported. Gives
+ * users at-a-glance insight into their FillIt usage.
+ */
+
+import React from 'react';
+import { StyleSheet, View, type ViewStyle } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../theme';
+import { LabelMedium, TitleLarge } from '../ui';
+
+/** A single stat to display */
+interface StatItem {
+  label: string;
+  value: number;
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+}
+
+/** Props for the QuickStats component */
+export interface QuickStatsProps {
+  /** Total number of documents in the store */
+  readonly documentCount: number;
+  /** Total number of user profiles */
+  readonly profileCount: number;
+  /** Number of documents that have been exported */
+  readonly exportedCount: number;
+}
+
+/**
+ * Horizontal row of quick-stat cards.
+ *
+ * @example
+ * ```tsx
+ * <QuickStats documentCount={12} profileCount={2} exportedCount={5} />
+ * ```
+ */
+export function QuickStats({ documentCount, profileCount, exportedCount }: QuickStatsProps) {
+  const { theme } = useTheme();
+
+  const stats: StatItem[] = [
+    {
+      label: 'Documents',
+      value: documentCount,
+      icon: 'document-text-outline',
+    },
+    { label: 'Profiles', value: profileCount, icon: 'people-outline' },
+    { label: 'Exported', value: exportedCount, icon: 'download-outline' },
+  ];
+
+  const cardStyle: ViewStyle = {
+    flex: 1,
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radii.md,
+    padding: theme.spacing.md,
+    alignItems: 'center',
+    ...theme.elevations.sm,
+  };
+
+  return (
+    <View style={[styles.row, { gap: theme.spacing.sm }]} testID="quick-stats">
+      {stats.map((stat) => (
+        <View key={stat.label} style={cardStyle}>
+          <Ionicons
+            name={stat.icon}
+            size={20}
+            color={theme.colors.primary}
+            style={{ marginBottom: theme.spacing.xs }}
+          />
+          <TitleLarge>{String(stat.value)}</TitleLarge>
+          <LabelMedium color="secondary">{stat.label}</LabelMedium>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+QuickStats.displayName = 'QuickStats';
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+  },
+});

--- a/apps/mobile/src/components/home/RecentDocuments.tsx
+++ b/apps/mobile/src/components/home/RecentDocuments.tsx
@@ -1,0 +1,131 @@
+/**
+ * Recent documents list for the home dashboard.
+ *
+ * Displays the last 5 documents as pressable cards with a title,
+ * date, and status chip. Shows the EmptyDashboard component when
+ * there are no documents, and skeleton placeholders while loading.
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import type { ProcessedDocument, ProcessingStatus } from '@fillit/shared';
+
+import { useTheme } from '../../theme';
+import { HeadingMedium } from '../ui';
+import { SkeletonDocumentCard } from '../skeleton';
+
+import { DocumentCard } from './DocumentCard';
+import { EmptyDashboard } from './EmptyDashboard';
+
+/** Props for the RecentDocuments component */
+export interface RecentDocumentsProps {
+  /** Documents sorted by most recent first */
+  readonly documents: ProcessedDocument[];
+  /** Whether the document store is still loading */
+  readonly isLoading: boolean;
+  /** Called when a document card is pressed */
+  readonly onDocumentPress?: (id: string) => void;
+}
+
+/** Maximum number of recent documents to display */
+const MAX_RECENT = 5;
+
+/** Map processing status to a chip color */
+export function getStatusChipColor(
+  status: ProcessingStatus,
+): 'default' | 'primary' | 'success' | 'warning' | 'info' {
+  const map: Record<ProcessingStatus, 'default' | 'primary' | 'success' | 'warning' | 'info'> = {
+    scanned: 'default',
+    ocr_complete: 'info',
+    fields_detected: 'info',
+    matched: 'primary',
+    reviewed: 'warning',
+    exported: 'success',
+  };
+  return map[status];
+}
+
+/** Format a status value for display */
+export function formatStatus(status: ProcessingStatus): string {
+  const labels: Record<ProcessingStatus, string> = {
+    scanned: 'Scanned',
+    ocr_complete: 'OCR Done',
+    fields_detected: 'Fields Found',
+    matched: 'Matched',
+    reviewed: 'Reviewed',
+    exported: 'Exported',
+  };
+  return labels[status];
+}
+
+/**
+ * Recent documents section with heading, cards, and empty/loading states.
+ *
+ * @example
+ * ```tsx
+ * <RecentDocuments
+ *   documents={recentDocs}
+ *   isLoading={isLoading}
+ *   onDocumentPress={(id) => router.push(`/document/${id}`)}
+ * />
+ * ```
+ */
+export function RecentDocuments({ documents, isLoading, onDocumentPress }: RecentDocumentsProps) {
+  const { theme } = useTheme();
+  const recent = documents.slice(0, MAX_RECENT);
+
+  return (
+    <View style={{ marginTop: theme.spacing['2xl'] }} testID="recent-documents">
+      <HeadingMedium style={{ marginBottom: theme.spacing.md }}>Recent Documents</HeadingMedium>
+
+      {isLoading ? (
+        <LoadingSkeleton />
+      ) : recent.length === 0 ? (
+        <EmptyDashboard />
+      ) : (
+        <DocumentList documents={recent} onDocumentPress={onDocumentPress} />
+      )}
+    </View>
+  );
+}
+
+RecentDocuments.displayName = 'RecentDocuments';
+
+// ---------------------------------------------------------------------------
+// Sub-components (keep functions under 80 lines)
+// ---------------------------------------------------------------------------
+
+/** Skeleton loading state for the document list */
+function LoadingSkeleton() {
+  const { theme } = useTheme();
+
+  return (
+    <View style={{ gap: theme.spacing.md }}>
+      <SkeletonDocumentCard />
+      <SkeletonDocumentCard />
+    </View>
+  );
+}
+
+LoadingSkeleton.displayName = 'LoadingSkeleton';
+
+/** Rendered list of document cards */
+function DocumentList({
+  documents,
+  onDocumentPress,
+}: {
+  documents: ProcessedDocument[];
+  onDocumentPress?: (id: string) => void;
+}) {
+  const { theme } = useTheme();
+
+  return (
+    <View style={{ gap: theme.spacing.md }}>
+      {documents.map((doc) => (
+        <DocumentCard key={doc.id} document={doc} onPress={onDocumentPress} />
+      ))}
+    </View>
+  );
+}
+
+DocumentList.displayName = 'DocumentList';

--- a/apps/mobile/src/components/home/ScanFAB.tsx
+++ b/apps/mobile/src/components/home/ScanFAB.tsx
@@ -1,0 +1,83 @@
+/**
+ * Floating action button for scanning documents.
+ *
+ * Absolutely positioned in the bottom-right corner of the screen,
+ * using the primary brand color. This is the primary CTA on the
+ * home dashboard.
+ */
+
+import React from 'react';
+import { Alert, Pressable, StyleSheet, type ViewStyle } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../theme';
+
+/** Size of the FAB circle in points */
+const FAB_SIZE = 64;
+
+/** Props for the ScanFAB component */
+export interface ScanFABProps {
+  /** Override the default press handler */
+  readonly onPress?: () => void;
+  /** Test ID for E2E tests */
+  readonly testID?: string;
+}
+
+/**
+ * Scan document floating action button.
+ *
+ * @example
+ * ```tsx
+ * <ScanFAB />
+ * <ScanFAB onPress={() => router.push('/scan')} />
+ * ```
+ */
+export function ScanFAB({ onPress, testID = 'scan-fab' }: ScanFABProps) {
+  const { theme } = useTheme();
+
+  const handlePress = () => {
+    if (onPress) {
+      onPress();
+      return;
+    }
+    Alert.alert('Coming Soon', 'Document scanning will be available in a future update.');
+  };
+
+  const fabStyle: ViewStyle = {
+    ...styles.fab,
+    backgroundColor: theme.colors.primary,
+    ...theme.elevations.lg,
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={({ pressed }) => [fabStyle, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel="Scan a document"
+      testID={testID}
+    >
+      <Ionicons name="scan" size={28} color={theme.colors.onPrimary} />
+    </Pressable>
+  );
+}
+
+ScanFAB.displayName = 'ScanFAB';
+
+const styles = StyleSheet.create({
+  fab: {
+    position: 'absolute',
+    bottom: 24,
+    right: 24,
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: FAB_SIZE / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10,
+  },
+  pressed: {
+    opacity: 0.85,
+    transform: [{ scale: 0.95 }],
+  },
+});

--- a/apps/mobile/src/components/home/index.ts
+++ b/apps/mobile/src/components/home/index.ts
@@ -1,0 +1,15 @@
+// Home dashboard component public API
+
+export { ScanFAB } from './ScanFAB';
+export type { ScanFABProps } from './ScanFAB';
+
+export { EmptyDashboard } from './EmptyDashboard';
+
+export { QuickStats } from './QuickStats';
+export type { QuickStatsProps } from './QuickStats';
+
+export { RecentDocuments } from './RecentDocuments';
+export type { RecentDocumentsProps } from './RecentDocuments';
+
+export { DocumentCard } from './DocumentCard';
+export type { DocumentCardProps } from './DocumentCard';


### PR DESCRIPTION
## Summary

- Replaces placeholder home screen with a full-featured dashboard
- Adds a prominent **Scan FAB** (floating action button) as the primary CTA, absolutely positioned bottom-right with primary brand color
- Adds **Scan** and **Import** quick-action buttons with coming-soon placeholder alerts
- Adds **Quick Stats** row showing documents processed, profiles count, and exported count
- Adds **Recent Documents** list (last 5, sorted by date) with pressable cards showing title, date, page count, and status chips (scanned, matched, exported, etc.)
- Adds **Empty Dashboard** state for new users with illustration icon and guidance text
- Uses **skeleton loading** (`SkeletonDocumentCard`) while stores initialize
- All components split into focused sub-components under `src/components/home/` to stay within the 80-line ESLint function limit

## New Files

- `apps/mobile/src/components/home/ScanFAB.tsx` - Floating action button
- `apps/mobile/src/components/home/EmptyDashboard.tsx` - Empty state for new users
- `apps/mobile/src/components/home/QuickStats.tsx` - Stats row
- `apps/mobile/src/components/home/RecentDocuments.tsx` - Recent documents list with loading/empty states
- `apps/mobile/src/components/home/DocumentCard.tsx` - Individual document card
- `apps/mobile/src/components/home/index.ts` - Public API barrel export

## Modified Files

- `apps/mobile/app/(tabs)/home.tsx` - Rewritten to compose new home components

## Test plan

- [ ] Verify the home screen renders with the hero section, quick actions, stats, and empty state
- [ ] Verify the Scan FAB is visible and positioned bottom-right, floating over scroll content
- [ ] Verify tapping Scan FAB / Scan button / Import button shows "Coming Soon" alert
- [ ] Verify quick stats show 0/0/0 for a fresh install
- [ ] Verify skeleton loading displays briefly while stores initialize
- [ ] Verify recent documents appear as cards when documents exist in the store
- [ ] Verify document cards show title, date, page count, and status chip
- [ ] Verify empty state shows when no documents exist
- [ ] Verify dark mode renders correctly with proper theme colors
- [ ] Verify existing tests pass (no regressions)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)