### PR TITLE
feat(mobile): build scan review screen (S-40)

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -9,6 +9,7 @@
 import React, { useEffect } from 'react';
 import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useRouter } from 'expo-router';
 
 import { useTheme } from '../../src/theme';
 import { Button, DisplayMedium, BodyLarge } from '../../src/components/ui';
@@ -29,9 +30,10 @@ import {
 
 export default function HomeScreen() {
   useStoreInitialization();
+  const router = useRouter();
   const { scan, isScanning } = useScanDocument({
-    onSuccess: (_id, pageCount) => {
-      Alert.alert('Scan Complete', `Successfully scanned ${pageCount} page(s).`);
+    onSuccess: (id) => {
+      router.push(`/scan/${id}` as never);
     },
   });
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -47,6 +47,7 @@ function RootNavigator() {
       <Stack.Screen name="profile/emergency/index" options={{ headerShown: false }} />
       <Stack.Screen name="profile/emergency/add" options={{ headerShown: false }} />
       <Stack.Screen name="profile/emergency/[id]" options={{ headerShown: false }} />
+      <Stack.Screen name="scan/[id]" options={{ headerShown: false }} />
       <Stack.Screen name="__e2e" options={{ headerShown: true, headerTitle: 'E2E Tests' }} />
     </Stack>
   );

--- a/apps/mobile/app/scan/[id].tsx
+++ b/apps/mobile/app/scan/[id].tsx
@@ -1,0 +1,122 @@
+/**
+ * Scan Review Screen (S-40)
+ *
+ * Displays scanned page thumbnails in a reorderable list.
+ * Users can delete pages, retake individual pages, reorder,
+ * and confirm to advance to the OCR stage.
+ */
+
+import React from 'react';
+import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import { useTheme } from '../../src/theme';
+import { Button, BodyLarge } from '../../src/components/ui';
+import { ScreenHeader } from '../../src/components/profile/ScreenHeader';
+import { PageThumbnail } from '../../src/components/scan';
+import { useScanReview } from '../../src/hooks/useScanReview';
+
+export default function ScanReviewScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { theme } = useTheme();
+
+  const { pages, isBusy, movePageUp, movePageDown, removePage, retakePage, confirm, canConfirm } =
+    useScanReview({
+      documentId: id ?? '',
+      onConfirm: () => {
+        // Navigate back to home for now — OCR screen comes in a later story
+        router.replace('/(tabs)/home');
+      },
+    });
+
+  if (!id) {
+    return (
+      <View style={[styles.root, { backgroundColor: theme.colors.background }]}>
+        <ScreenHeader title="Review Scan" onBack={() => router.back()} />
+        <View style={styles.center}>
+          <BodyLarge color="secondary">No document ID provided.</BodyLarge>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.root, { backgroundColor: theme.colors.background }]}
+      testID="scan-review-screen"
+    >
+      <ScreenHeader title="Review Scan" onBack={() => router.back()} />
+
+      {pages.length === 0 ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <BodyLarge color="secondary" style={{ marginTop: theme.spacing.md }}>
+            Loading pages...
+          </BodyLarge>
+        </View>
+      ) : (
+        <>
+          <FlatList
+            data={pages}
+            keyExtractor={(page) => page.id}
+            contentContainerStyle={{ padding: theme.spacing.lg }}
+            renderItem={({ item: page }) => (
+              <PageThumbnail
+                imageUri={page.originalImageUri}
+                pageNumber={page.pageNumber}
+                totalPages={pages.length}
+                disabled={isBusy}
+                onMoveUp={() => movePageUp(page.id)}
+                onMoveDown={() => movePageDown(page.id)}
+                onDelete={() => removePage(page.id)}
+                onRetake={() => retakePage(page.id)}
+              />
+            )}
+          />
+
+          <View
+            style={[
+              styles.footer,
+              {
+                padding: theme.spacing.lg,
+                backgroundColor: theme.colors.surface,
+                borderTopWidth: 1,
+                borderTopColor: theme.colors.outline,
+              },
+            ]}
+          >
+            <BodyLarge color="secondary" align="center" style={{ marginBottom: theme.spacing.sm }}>
+              {pages.length} {pages.length === 1 ? 'page' : 'pages'} scanned
+            </BodyLarge>
+            <Button
+              label={isBusy ? 'Processing...' : 'Confirm & Continue'}
+              variant="primary"
+              size="lg"
+              fullWidth
+              onPress={confirm}
+              disabled={!canConfirm || isBusy}
+              loading={isBusy}
+              accessibilityLabel="Confirm scan and proceed to processing"
+              testID="confirm-scan-button"
+            />
+          </View>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  footer: {
+    alignItems: 'center',
+  },
+});

--- a/apps/mobile/src/components/scan/PageThumbnail.tsx
+++ b/apps/mobile/src/components/scan/PageThumbnail.tsx
@@ -1,0 +1,223 @@
+/**
+ * Page thumbnail card for the scan review screen.
+ *
+ * Displays a scanned page image with controls for reorder, delete, and retake.
+ */
+
+import React from 'react';
+import { Image, Pressable, StyleSheet, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../../theme';
+import { BodySmall } from '../ui';
+
+interface PageThumbnailProps {
+  readonly imageUri: string;
+  readonly pageNumber: number;
+  readonly totalPages: number;
+  readonly disabled?: boolean;
+  readonly onMoveUp: () => void;
+  readonly onMoveDown: () => void;
+  readonly onDelete: () => void;
+  readonly onRetake: () => void;
+}
+
+export function PageThumbnail({
+  imageUri,
+  pageNumber,
+  totalPages,
+  disabled = false,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+  onRetake,
+}: PageThumbnailProps) {
+  const { theme } = useTheme();
+  const isFirst = pageNumber === 1;
+  const isLast = pageNumber === totalPages;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: theme.colors.surface,
+          borderRadius: theme.radii.lg,
+          padding: theme.spacing.md,
+          ...theme.elevations.sm,
+        },
+      ]}
+      testID={`page-thumbnail-${pageNumber}`}
+    >
+      <View style={styles.row}>
+        {/* Thumbnail image */}
+        <View
+          style={[
+            styles.imageWrapper,
+            {
+              borderRadius: theme.radii.md,
+              borderColor: theme.colors.outlineVariant,
+            },
+          ]}
+        >
+          <Image
+            source={{ uri: imageUri }}
+            style={[styles.image, { borderRadius: theme.radii.md }]}
+            resizeMode="cover"
+            accessibilityLabel={`Page ${pageNumber}`}
+          />
+          <View
+            style={[
+              styles.badge,
+              {
+                backgroundColor: theme.colors.primary,
+                borderRadius: theme.radii.full,
+              },
+            ]}
+          >
+            <BodySmall style={{ color: theme.colors.onPrimary }}>{String(pageNumber)}</BodySmall>
+          </View>
+        </View>
+
+        {/* Controls */}
+        <View style={[styles.controls, { gap: theme.spacing.sm }]}>
+          {/* Reorder buttons */}
+          <View style={[styles.reorderGroup, { gap: theme.spacing.xs }]}>
+            <IconButton
+              icon="chevron-up"
+              label={`Move page ${pageNumber} up`}
+              onPress={onMoveUp}
+              disabled={disabled || isFirst}
+              color={theme.colors.onSurfaceVariant}
+              disabledColor={theme.colors.outlineVariant}
+            />
+            <IconButton
+              icon="chevron-down"
+              label={`Move page ${pageNumber} down`}
+              onPress={onMoveDown}
+              disabled={disabled || isLast}
+              color={theme.colors.onSurfaceVariant}
+              disabledColor={theme.colors.outlineVariant}
+            />
+          </View>
+
+          {/* Action buttons */}
+          <View style={[styles.actionGroup, { gap: theme.spacing.sm }]}>
+            <IconButton
+              icon="camera-outline"
+              label={`Retake page ${pageNumber}`}
+              onPress={onRetake}
+              disabled={disabled}
+              color={theme.colors.primary}
+              disabledColor={theme.colors.outlineVariant}
+            />
+            <IconButton
+              icon="trash-outline"
+              label={`Delete page ${pageNumber}`}
+              onPress={onDelete}
+              disabled={disabled}
+              color={theme.colors.error}
+              disabledColor={theme.colors.outlineVariant}
+            />
+          </View>
+        </View>
+      </View>
+
+      <BodySmall color="secondary" style={{ marginTop: theme.spacing.xs }}>
+        Page {pageNumber} of {totalPages}
+      </BodySmall>
+    </View>
+  );
+}
+
+PageThumbnail.displayName = 'PageThumbnail';
+
+// ---------------------------------------------------------------------------
+// Icon button helper
+// ---------------------------------------------------------------------------
+
+function IconButton({
+  icon,
+  label,
+  onPress,
+  disabled,
+  color,
+  disabledColor,
+}: {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  label: string;
+  onPress: () => void;
+  disabled: boolean;
+  color: string;
+  disabledColor: string;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      style={({ pressed }) => [styles.iconButton, pressed && !disabled && styles.iconButtonPressed]}
+    >
+      <Ionicons name={icon} size={22} color={disabled ? disabledColor : color} />
+    </Pressable>
+  );
+}
+
+IconButton.displayName = 'IconButton';
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  imageWrapper: {
+    width: 100,
+    height: 140,
+    borderWidth: 1,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  badge: {
+    position: 'absolute',
+    top: 6,
+    left: 6,
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  controls: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginLeft: 16,
+  },
+  reorderGroup: {
+    alignItems: 'center',
+  },
+  actionGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconButton: {
+    padding: 8,
+  },
+  iconButtonPressed: {
+    opacity: 0.6,
+  },
+});

--- a/apps/mobile/src/components/scan/index.ts
+++ b/apps/mobile/src/components/scan/index.ts
@@ -1,0 +1,1 @@
+export { PageThumbnail } from './PageThumbnail';

--- a/apps/mobile/src/hooks/useScanReview.ts
+++ b/apps/mobile/src/hooks/useScanReview.ts
@@ -1,0 +1,214 @@
+/**
+ * Hook: useScanReview
+ *
+ * Manages the scan review screen logic:
+ *   - Load document and pages from the store
+ *   - Reorder pages (move up/down)
+ *   - Delete a page
+ *   - Retake a page (re-scan single page, replace image)
+ *   - Confirm and advance pipeline to OCR
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { Alert } from 'react-native';
+
+import type { DocumentPage } from '@fillit/shared';
+import { scanDocument } from '../services/scanner/documentScanner';
+import { saveFile, deleteFile } from '../services/storage/fileStorage';
+import { useDocumentStore, selectDocumentById } from '../stores/document-store';
+import { useProcessingStore } from '../stores/processing-store';
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseScanReviewOptions {
+  documentId: string;
+  onConfirm?: (documentId: string) => void;
+}
+
+export interface UseScanReviewReturn {
+  /** The pages in display order. */
+  pages: DocumentPage[];
+  /** Whether any async operation is in progress. */
+  isBusy: boolean;
+  /** Move a page up in the order. */
+  movePageUp: (pageId: string) => Promise<void>;
+  /** Move a page down in the order. */
+  movePageDown: (pageId: string) => Promise<void>;
+  /** Delete a page from the document. */
+  removePage: (pageId: string) => void;
+  /** Retake a page using the scanner. */
+  retakePage: (pageId: string) => Promise<void>;
+  /** Confirm review and advance to OCR stage. */
+  confirm: () => void;
+  /** Whether confirm is possible (has at least one page). */
+  canConfirm: boolean;
+}
+
+export function useScanReview({
+  documentId,
+  onConfirm,
+}: UseScanReviewOptions): UseScanReviewReturn {
+  const [isBusy, setIsBusy] = useState(false);
+  const isBusyRef = useRef(false);
+
+  const document = useDocumentStore(selectDocumentById(documentId));
+  const updatePage = useDocumentStore((s) => s.updatePage);
+  const deletePage = useDocumentStore((s) => s.deletePage);
+  const completeCurrentStage = useProcessingStore((s) => s.completeCurrentStage);
+  const advanceStage = useProcessingStore((s) => s.advanceStage);
+
+  const pages = document?.pages
+    ? [...document.pages].sort((a, b) => a.pageNumber - b.pageNumber)
+    : [];
+
+  const setBusy = (busy: boolean) => {
+    isBusyRef.current = busy;
+    setIsBusy(busy);
+  };
+
+  const movePageUp = useCallback(
+    async (pageId: string) => {
+      if (isBusyRef.current) return;
+      const idx = pages.findIndex((p) => p.id === pageId);
+      if (idx <= 0) return;
+
+      setBusy(true);
+      try {
+        const current = pages[idx]!;
+        const above = pages[idx - 1]!;
+        await updatePage(current.id, { pageNumber: above.pageNumber }, documentId);
+        await updatePage(above.id, { pageNumber: current.pageNumber }, documentId);
+      } catch {
+        Alert.alert('Error', 'Failed to reorder pages.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [pages, updatePage, documentId],
+  );
+
+  const movePageDown = useCallback(
+    async (pageId: string) => {
+      if (isBusyRef.current) return;
+      const idx = pages.findIndex((p) => p.id === pageId);
+      if (idx < 0 || idx >= pages.length - 1) return;
+
+      setBusy(true);
+      try {
+        const current = pages[idx]!;
+        const below = pages[idx + 1]!;
+        await updatePage(current.id, { pageNumber: below.pageNumber }, documentId);
+        await updatePage(below.id, { pageNumber: current.pageNumber }, documentId);
+      } catch {
+        Alert.alert('Error', 'Failed to reorder pages.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [pages, updatePage, documentId],
+  );
+
+  const removePage = useCallback(
+    (pageId: string) => {
+      if (isBusyRef.current) return;
+      if (pages.length <= 1) {
+        Alert.alert('Cannot Delete', 'A document must have at least one page.');
+        return;
+      }
+
+      Alert.alert('Delete Page', 'Are you sure you want to delete this page?', [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            setBusy(true);
+            try {
+              const page = pages.find((p) => p.id === pageId);
+              if (page) {
+                await deletePage(pageId, documentId);
+                // Delete the image file
+                try {
+                  deleteFile(page.originalImageUri);
+                } catch {
+                  // File cleanup is non-fatal
+                }
+                // Renumber remaining pages
+                const remaining = pages.filter((p) => p.id !== pageId);
+                for (let i = 0; i < remaining.length; i++) {
+                  const p = remaining[i]!;
+                  if (p.pageNumber !== i + 1) {
+                    await updatePage(p.id, { pageNumber: i + 1 }, documentId);
+                  }
+                }
+              }
+            } catch {
+              Alert.alert('Error', 'Failed to delete page.');
+            } finally {
+              setBusy(false);
+            }
+          },
+        },
+      ]);
+    },
+    [pages, deletePage, updatePage, documentId],
+  );
+
+  const retakePage = useCallback(
+    async (pageId: string) => {
+      if (isBusyRef.current) return;
+
+      const page = pages.find((p) => p.id === pageId);
+      if (!page) return;
+
+      setBusy(true);
+      try {
+        const result = await scanDocument({ pageLimit: 1 });
+
+        if (result.status === 'canceled') {
+          return;
+        }
+
+        if (result.status === 'error') {
+          Alert.alert('Scan Failed', result.error.message);
+          return;
+        }
+
+        const newImageUri = result.data.pages[0];
+        if (!newImageUri) return;
+
+        // Save the new image, overwriting the old one
+        const filename = `page-${page.pageNumber}.jpg`;
+        const savedUri = saveFile(documentId, 'originals', filename, newImageUri);
+
+        // Update page record with new image URI
+        await updatePage(page.id, { originalImageUri: savedUri }, documentId);
+      } catch {
+        Alert.alert('Error', 'Failed to retake page.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [pages, updatePage, documentId],
+  );
+
+  const confirm = useCallback(() => {
+    if (pages.length === 0) return;
+    completeCurrentStage();
+    advanceStage();
+    onConfirm?.(documentId);
+  }, [pages.length, completeCurrentStage, advanceStage, onConfirm, documentId]);
+
+  return {
+    pages,
+    isBusy,
+    movePageUp,
+    movePageDown,
+    removePage,
+    retakePage,
+    confirm,
+    canConfirm: pages.length > 0,
+  };
+}

--- a/apps/mobile/src/services/storage/documentCrud.ts
+++ b/apps/mobile/src/services/storage/documentCrud.ts
@@ -78,6 +78,8 @@ export interface CreatePageInput {
 
 /** Input for updating an existing page. */
 export interface UpdatePageInput {
+  pageNumber?: number;
+  originalImageUri?: string;
   processedImageUri?: string;
   ocrText?: string;
   width?: number;
@@ -420,6 +422,14 @@ export async function updatePage(id: string, input: UpdatePageInput): Promise<Do
   const setClauses: string[] = [];
   const params: (string | number | null)[] = [];
 
+  if (input.pageNumber !== undefined) {
+    setClauses.push('page_number = ?');
+    params.push(input.pageNumber);
+  }
+  if (input.originalImageUri !== undefined) {
+    setClauses.push('original_image_uri = ?');
+    params.push(input.originalImageUri);
+  }
   if (input.processedImageUri !== undefined) {
     setClauses.push('processed_image_uri = ?');
     params.push(input.processedImageUri);


### PR DESCRIPTION
## Summary
- Adds scan review screen (`/scan/[id]`) where users can review scanned pages before OCR
- Page management: reorder (move up/down), delete with renumbering, single-page retake via scanner
- Confirm action advances the processing pipeline from reviewing → OCR stage
- Extended `UpdatePageInput` to support `pageNumber` and `originalImageUri` updates
- Updated home screen to navigate to review screen after successful scan

## Changes
- `apps/mobile/app/scan/[id].tsx` — New review screen route
- `apps/mobile/src/hooks/useScanReview.ts` — Review logic hook
- `apps/mobile/src/components/scan/PageThumbnail.tsx` — Thumbnail card with controls
- `apps/mobile/src/services/storage/documentCrud.ts` — Extended UpdatePageInput
- `apps/mobile/app/_layout.tsx` — Registered new route
- `apps/mobile/app/(tabs)/home.tsx` — Navigate to review on scan success

## Test plan
- [ ] Scan a document → verify navigation to review screen
- [ ] Verify all scanned pages display as thumbnails with page numbers
- [ ] Test move up/down reordering on multi-page documents
- [ ] Test deleting a page (verify remaining pages renumber correctly)
- [ ] Test retake (verify scanner launches for single page, image replaces)
- [ ] Verify Confirm button advances pipeline and navigates to home
- [ ] Verify single-page documents cannot have their page deleted
- [ ] Type-check passes, all 1448 existing tests pass

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)