### PR TITLE
feat(mobile): implement document file import (S-41)

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -14,6 +14,7 @@ import { useTheme } from '../../src/theme';
 import { Button, DisplayMedium, BodyLarge } from '../../src/components/ui';
 import { ScanFAB, QuickStats, RecentDocuments } from '../../src/components/home';
 import { useScanDocument } from '../../src/hooks/useScanDocument';
+import { useImportDocument } from '../../src/hooks/useImportDocument';
 import {
   useDocumentStore,
   selectDocuments,
@@ -34,11 +35,21 @@ export default function HomeScreen() {
       Alert.alert('Scan Complete', `Successfully scanned ${pageCount} page(s).`);
     },
   });
+  const { importFiles, isImporting } = useImportDocument({
+    onSuccess: (_id, pageCount) => {
+      Alert.alert('Import Complete', `Successfully imported ${pageCount} image(s).`);
+    },
+  });
 
   return (
     <View style={styles.root} testID="home-screen">
-      <DashboardContent scan={scan} isScanning={isScanning} />
-      <ScanFAB onPress={scan} disabled={isScanning} />
+      <DashboardContent
+        scan={scan}
+        isScanning={isScanning}
+        importFiles={importFiles}
+        isImporting={isImporting}
+      />
+      <ScanFAB onPress={scan} disabled={isScanning || isImporting} />
     </View>
   );
 }
@@ -63,7 +74,17 @@ function useStoreInitialization() {
 // ---------------------------------------------------------------------------
 
 /** Scrollable dashboard body with hero, actions, stats, and documents */
-function DashboardContent({ scan, isScanning }: { scan: () => void; isScanning: boolean }) {
+function DashboardContent({
+  scan,
+  isScanning,
+  importFiles,
+  isImporting,
+}: {
+  scan: () => void;
+  isScanning: boolean;
+  importFiles: () => void;
+  isImporting: boolean;
+}) {
   const { theme } = useTheme();
   const documents = useDocumentStore(selectDocuments);
   const isLoading = useDocumentStore(selectDocIsLoading);
@@ -84,7 +105,12 @@ function DashboardContent({ scan, isScanning }: { scan: () => void; isScanning: 
       contentContainerStyle={[styles.content, { padding: theme.spacing.lg }]}
     >
       <HeroSection />
-      <QuickActions scan={scan} isScanning={isScanning} />
+      <QuickActions
+        scan={scan}
+        isScanning={isScanning}
+        importFiles={importFiles}
+        isImporting={isImporting}
+      />
 
       {storesReady ? (
         <>
@@ -127,12 +153,18 @@ function HeroSection() {
 HeroSection.displayName = 'HeroSection';
 
 /** Scan and Import action buttons */
-function QuickActions({ scan, isScanning }: { scan: () => void; isScanning: boolean }) {
+function QuickActions({
+  scan,
+  isScanning,
+  importFiles,
+  isImporting,
+}: {
+  scan: () => void;
+  isScanning: boolean;
+  importFiles: () => void;
+  isImporting: boolean;
+}) {
   const { theme } = useTheme();
-
-  const handleImport = () => {
-    Alert.alert('Coming Soon', 'Document import will be available in a future update.');
-  };
 
   return (
     <View style={[styles.quickActions, { gap: theme.spacing.md, marginBottom: theme.spacing.xl }]}>
@@ -143,6 +175,7 @@ function QuickActions({ scan, isScanning }: { scan: () => void; isScanning: bool
         fullWidth
         onPress={scan}
         loading={isScanning}
+        disabled={isImporting}
         iconLeft={
           isScanning ? undefined : <Ionicons name="scan" size={22} color={theme.colors.onPrimary} />
         }
@@ -151,13 +184,17 @@ function QuickActions({ scan, isScanning }: { scan: () => void; isScanning: bool
         style={{ flex: 1 }}
       />
       <Button
-        label="Import"
+        label={isImporting ? 'Importing...' : 'Import'}
         variant="outline"
         size="lg"
         fullWidth
-        onPress={handleImport}
+        onPress={importFiles}
+        loading={isImporting}
+        disabled={isScanning}
         iconLeft={
-          <Ionicons name="document-attach-outline" size={22} color={theme.colors.primary} />
+          isImporting ? undefined : (
+            <Ionicons name="document-attach-outline" size={22} color={theme.colors.primary} />
+          )
         }
         accessibilityLabel="Import a document"
         testID="action-import"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -28,6 +28,7 @@
     "expo-constants": "~55.0.9",
     "expo-crypto": "^55.0.10",
     "expo-dev-client": "~55.0.18",
+    "expo-document-picker": "55.0.10-canary-20260327-0789fbc",
     "expo-file-system": "^55.0.11",
     "expo-font": "^55.0.4",
     "expo-linking": "~55.0.8",

--- a/apps/mobile/src/hooks/useImportDocument.ts
+++ b/apps/mobile/src/hooks/useImportDocument.ts
@@ -1,0 +1,247 @@
+/**
+ * Hook: useImportDocument
+ *
+ * Orchestrates the document import flow:
+ *   1. Launch native document picker for images and PDFs
+ *   2. Validate selected files (format, size)
+ *   3. Create a document record in the database
+ *   4. Save imported images to local file storage
+ *   5. Create page records for each imported image
+ *   6. Advance the processing pipeline to the review stage
+ *
+ * Currently supports image import (JPEG, PNG). PDF support is scaffolded
+ * and will be fully implemented with image extraction in S-45.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { Alert, Image } from 'react-native';
+import * as DocumentPicker from 'expo-document-picker';
+
+import { useDocumentStore } from '../stores/document-store';
+import { useProcessingStore } from '../stores/processing-store';
+import { saveFile } from '../services/storage/fileStorage';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum file size in bytes (20 MB). */
+const MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024;
+
+/** Accepted MIME types for the document picker. */
+const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/jpg', 'application/pdf'];
+
+/** Image MIME types we can process directly. */
+const IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/jpg']);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateId(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+function getImageSize(uri: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    Image.getSize(
+      uri,
+      (width, height) => resolve({ width, height }),
+      (error) => reject(error),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseImportDocumentOptions {
+  /** Callback invoked after a successful import with the new document ID. */
+  onSuccess?: (documentId: string, pageCount: number) => void;
+}
+
+export interface UseImportDocumentReturn {
+  /** Launch the document picker and import selected files. */
+  importFiles: () => Promise<void>;
+  /** Whether the import is currently in progress. */
+  isImporting: boolean;
+  /** Import progress (0 to 1) for multi-file imports. */
+  progress: number;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useImportDocument(options?: UseImportDocumentOptions): UseImportDocumentReturn {
+  const [isImporting, setIsImporting] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const isImportingRef = useRef(false);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const createDocument = useDocumentStore((s) => s.createDocument);
+  const deleteDocument = useDocumentStore((s) => s.deleteDocument);
+  const createPage = useDocumentStore((s) => s.createPage);
+  const startProcessing = useProcessingStore((s) => s.startProcessing);
+  const completeCurrentStage = useProcessingStore((s) => s.completeCurrentStage);
+  const advanceStage = useProcessingStore((s) => s.advanceStage);
+  const resetProcessing = useProcessingStore((s) => s.reset);
+
+  const importFiles = useCallback(async () => {
+    if (isImportingRef.current) return;
+    isImportingRef.current = true;
+    setIsImporting(true);
+    setProgress(0);
+
+    let documentId: string | null = null;
+
+    try {
+      // Launch the document picker
+      const result = await DocumentPicker.getDocumentAsync({
+        type: ACCEPTED_TYPES,
+        multiple: true,
+        copyToCacheDirectory: true,
+      });
+
+      if (result.canceled) {
+        return;
+      }
+
+      const assets = result.assets;
+      if (!assets || assets.length === 0) {
+        return;
+      }
+
+      // Separate images and PDFs
+      const imageAssets = assets.filter((a) => IMAGE_MIME_TYPES.has(a.mimeType ?? ''));
+      const pdfAssets = assets.filter((a) => a.mimeType === 'application/pdf');
+
+      if (imageAssets.length === 0 && pdfAssets.length > 0) {
+        Alert.alert(
+          'PDF Import Coming Soon',
+          'Full PDF page extraction will be available in a future update. Please import images (JPEG, PNG) for now.',
+        );
+        return;
+      }
+
+      if (imageAssets.length === 0) {
+        Alert.alert('No Valid Files', 'Please select JPEG or PNG image files.');
+        return;
+      }
+
+      // Notify about skipped PDFs
+      if (pdfAssets.length > 0) {
+        Alert.alert(
+          'Note',
+          `${pdfAssets.length} PDF file(s) were skipped. PDF import will be available in a future update. Importing ${imageAssets.length} image(s).`,
+        );
+      }
+
+      // Validate image files
+      const validAssets = [];
+      for (const asset of imageAssets) {
+        if (asset.size && asset.size > MAX_FILE_SIZE_BYTES) {
+          Alert.alert('File Too Large', `"${asset.name}" exceeds the 20 MB limit and was skipped.`);
+          continue;
+        }
+        validAssets.push(asset);
+      }
+
+      if (validAssets.length === 0) {
+        Alert.alert('No Valid Files', 'All selected files were too large or invalid.');
+        return;
+      }
+
+      // Create document record
+      documentId = generateId();
+      await createDocument({
+        id: documentId,
+        title:
+          validAssets.length === 1
+            ? (validAssets[0]!.name ?? 'Import')
+            : `Import ${new Date().toLocaleDateString()}`,
+        sourceType: 'import',
+      });
+
+      // Start processing pipeline
+      startProcessing(documentId);
+
+      // Save each image and create page records
+      for (let i = 0; i < validAssets.length; i++) {
+        const asset = validAssets[i]!;
+        const pageNumber = i + 1;
+        const extension = asset.mimeType === 'image/png' ? 'png' : 'jpg';
+        const filename = `page-${pageNumber}.${extension}`;
+
+        const savedUri = saveFile(documentId, 'originals', filename, asset.uri);
+
+        // Get image dimensions
+        let width = 0;
+        let height = 0;
+        try {
+          const size = await getImageSize(savedUri);
+          width = size.width;
+          height = size.height;
+        } catch {
+          // Dimension detection failure is non-fatal
+        }
+
+        await createPage({
+          id: generateId(),
+          documentId,
+          pageNumber,
+          originalImageUri: savedUri,
+          width,
+          height,
+        });
+
+        setProgress((i + 1) / validAssets.length);
+      }
+
+      // Complete scanning stage and advance to reviewing
+      completeCurrentStage();
+      advanceStage();
+
+      optionsRef.current?.onSuccess?.(documentId, validAssets.length);
+      documentId = null; // Mark success — skip cleanup
+    } catch (error) {
+      // Roll back partial state on failure
+      if (documentId) {
+        try {
+          await deleteDocument(documentId);
+        } catch {
+          // Cleanup failure is non-fatal
+        }
+        resetProcessing();
+      }
+
+      Alert.alert(
+        'Import Error',
+        error instanceof Error ? error.message : 'An unexpected error occurred while importing.',
+      );
+    } finally {
+      isImportingRef.current = false;
+      setIsImporting(false);
+      setProgress(0);
+    }
+  }, [
+    createDocument,
+    deleteDocument,
+    createPage,
+    startProcessing,
+    completeCurrentStage,
+    advanceStage,
+    resetProcessing,
+  ]);
+
+  return { importFiles, isImporting, progress };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       expo-dev-client:
         specifier: ~55.0.18
         version: 55.0.18(expo@55.0.8)(typescript@5.9.3)
+      expo-document-picker:
+        specifier: 55.0.10-canary-20260327-0789fbc
+        version: 55.0.10-canary-20260327-0789fbc(expo@55.0.8)
       expo-file-system:
         specifier: ^55.0.11
         version: 55.0.11(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))
@@ -2311,6 +2314,11 @@ packages:
     resolution: {integrity: sha512-UhduIh/6wQmFLIy1EeQJBCN09irOrC1kf/UMQ9CxXCkXit9SOtJx+26YfCmbrIRV/lYK2qZK8Y178/HNkt7yeA==}
     peerDependencies:
       expo: '*'
+
+  expo-document-picker@55.0.10-canary-20260327-0789fbc:
+    resolution: {integrity: sha512-atRA+99Z+aZZFAI/icwL+/Jv6gM9tDNt3I1TQLyfCzvgjGgP47yjcTKe9viCLg8pMEhkBmZ/ZgUoMHTsssRnyA==}
+    peerDependencies:
+      expo: 55.0.10-canary-20260327-0789fbc
 
   expo-file-system@55.0.11:
     resolution: {integrity: sha512-KMUd6OY375J9WD79ZvjvCDZMveT7YfgiGWdi58/gfuTBsr14TRuoPk8RRQHAtc4UquzWViKcHwna9aPY7/XPpw==}
@@ -6537,6 +6545,10 @@ snapshots:
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-dev-menu-interface: 55.0.1(expo@55.0.8)
+
+  expo-document-picker@55.0.10-canary-20260327-0789fbc(expo@55.0.8):
+    dependencies:
+      expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-file-system@55.0.11(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)):
     dependencies:


### PR DESCRIPTION
## Summary
- Adds document import flow allowing users to pick images (JPEG, PNG) from their device
- Validates file size (20 MB limit) and format before importing
- Creates document records with `sourceType: 'import'` and advances through the same processing pipeline as camera scans
- PDF selection is accepted in the picker but extraction is deferred to S-45 (image processing utilities) with a clear user-facing message
- Replaced the placeholder "Coming Soon" import button with the working import flow

## Changes
- `apps/mobile/src/hooks/useImportDocument.ts` — New import hook (picker, validation, save, pipeline)
- `apps/mobile/app/(tabs)/home.tsx` — Wired up Import button with loading/disabled states
- `apps/mobile/package.json` — Added `expo-document-picker` dependency
- `pnpm-lock.yaml` — Updated lockfile

## Test plan
- [ ] Tap Import → verify native file picker opens
- [ ] Select JPEG/PNG images → verify imported as document pages
- [ ] Select multiple images → verify all are saved as separate pages
- [ ] Select a file > 20 MB → verify size validation alert
- [ ] Select only PDFs → verify "PDF Coming Soon" alert
- [ ] Select mix of images + PDFs → verify images import, PDFs skipped with notice
- [ ] Verify Import button shows loading state during import
- [ ] Verify Scan button is disabled while importing (and vice versa)
- [ ] Type-check passes, all 1448 existing tests pass

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)