### PR TITLE
feat(mobile): build ML Kit OCR service (S-42)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
     "@expo/vector-icons": "^15.1.1",
     "@fillit/shared": "workspace:*",
     "@infinitered/react-native-mlkit-document-scanner": "^5.0.0",
+    "@infinitered/react-native-mlkit-text-recognition": "^5.0.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "^11.5.2",
     "expo": "~55.0.8",

--- a/apps/mobile/src/services/ocr/index.ts
+++ b/apps/mobile/src/services/ocr/index.ts
@@ -1,0 +1,9 @@
+export { performOcr, performOcrBatch, extractPlainText, extractBlocks } from './ocrService';
+export type {
+  OcrElement,
+  OcrLine,
+  OcrBlock,
+  OcrPageResult,
+  OcrResult,
+  OcrOptions,
+} from './ocrService';

--- a/apps/mobile/src/services/ocr/ocrService.ts
+++ b/apps/mobile/src/services/ocr/ocrService.ts
@@ -1,0 +1,231 @@
+/**
+ * OCR Service (S-42)
+ *
+ * Wraps @infinitered/react-native-mlkit-text-recognition to provide
+ * structured text extraction with bounding boxes and confidence scores.
+ * Processes scanned document page images and returns hierarchical OCR
+ * results (blocks → lines → elements) suitable for field detection.
+ *
+ * Platform support:
+ * - iOS/Android: ML Kit on-device text recognition
+ * - Web: Not supported (will be added in Phase 6 via tesseract.js)
+ */
+
+import { Platform } from 'react-native';
+
+import type { BoundingBox } from '@fillit/shared';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A recognized text element (word/number). */
+export interface OcrElement {
+  text: string;
+  bounds: BoundingBox;
+  languages: string[];
+}
+
+/** A recognized text line (row of elements). */
+export interface OcrLine {
+  text: string;
+  bounds: BoundingBox;
+  languages: string[];
+  elements: OcrElement[];
+}
+
+/** A recognized text block (paragraph/group of lines). */
+export interface OcrBlock {
+  text: string;
+  bounds: BoundingBox;
+  confidence: number;
+  languages: string[];
+  lines: OcrLine[];
+}
+
+/** Full OCR result for a single page. */
+export interface OcrPageResult {
+  /** The full extracted text from the page. */
+  text: string;
+  /** Structured text blocks with bounding boxes. */
+  blocks: OcrBlock[];
+  /** Number of text blocks found. */
+  blockCount: number;
+  /** Processing time in milliseconds. */
+  processingTimeMs: number;
+}
+
+/** Discriminated union for OCR outcomes. */
+export type OcrResult =
+  | { status: 'success'; data: OcrPageResult }
+  | { status: 'error'; error: Error }
+  | { status: 'no_text' };
+
+/** Options for OCR processing. */
+export interface OcrOptions {
+  /** Language hints to improve recognition accuracy. Defaults to ['en', 'af']. */
+  languageHints?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LANGUAGE_HINTS = ['en', 'af'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert ML Kit Rect (left/top/right/bottom) to BoundingBox (x/y/width/height).
+ */
+function rectToBoundingBox(rect: {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}): BoundingBox {
+  return {
+    x: rect.left,
+    y: rect.top,
+    width: rect.right - rect.left,
+    height: rect.bottom - rect.top,
+  };
+}
+
+/**
+ * Estimate confidence for a block based on recognized languages.
+ *
+ * ML Kit text recognition doesn't directly expose per-block confidence scores.
+ * We derive a heuristic: blocks with recognized languages matching our hints
+ * get higher confidence, blocks with unknown languages get lower confidence.
+ */
+function estimateBlockConfidence(recognizedLanguages: string[], languageHints: string[]): number {
+  if (recognizedLanguages.length === 0) {
+    return 0.6; // No language detected — moderate confidence
+  }
+
+  const hintSet = new Set(languageHints);
+  const matchCount = recognizedLanguages.filter((lang) => hintSet.has(lang)).length;
+
+  if (matchCount > 0) {
+    return 0.9; // Matches expected language — high confidence
+  }
+
+  return 0.7; // Recognized but unexpected language — moderate confidence
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Perform OCR on a page image using ML Kit text recognition.
+ *
+ * @param imageUri - The local file URI of the page image (JPEG/PNG).
+ * @param options - Optional OCR configuration.
+ * @returns A discriminated result: success with structured text, no_text, or error.
+ */
+export async function performOcr(imageUri: string, options?: OcrOptions): Promise<OcrResult> {
+  if (Platform.OS === 'web') {
+    return {
+      status: 'error',
+      error: new Error('OCR is not supported on web. Web OCR will be available in Phase 6.'),
+    };
+  }
+
+  const languageHints = options?.languageHints ?? DEFAULT_LANGUAGE_HINTS;
+  const startTime = Date.now();
+
+  try {
+    // Dynamic import to avoid bundling native module on web
+    const { recognizeText } = await import('@infinitered/react-native-mlkit-text-recognition');
+
+    const result = await recognizeText(imageUri);
+
+    if (!result.text || result.text.trim().length === 0) {
+      return { status: 'no_text' };
+    }
+
+    const blocks: OcrBlock[] = result.blocks.map((block) => ({
+      text: block.text,
+      bounds: rectToBoundingBox(block.frame),
+      confidence: estimateBlockConfidence(block.recognizedLanguages, languageHints),
+      languages: block.recognizedLanguages,
+      lines: block.lines.map((line) => ({
+        text: line.text,
+        bounds: rectToBoundingBox(line.frame),
+        languages: line.recognizedLanguages,
+        elements: line.elements.map((element) => ({
+          text: element.text,
+          bounds: rectToBoundingBox(element.frame),
+          languages: element.recognizedLanguages,
+        })),
+      })),
+    }));
+
+    const processingTimeMs = Date.now() - startTime;
+
+    return {
+      status: 'success',
+      data: {
+        text: result.text,
+        blocks,
+        blockCount: blocks.length,
+        processingTimeMs,
+      },
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
+/**
+ * Perform OCR on multiple page images sequentially.
+ *
+ * @param imageUris - Array of local file URIs.
+ * @param options - Optional OCR configuration.
+ * @param onProgress - Optional callback invoked after each page completes (0 to 1).
+ * @returns Array of OCR results, one per page.
+ */
+export async function performOcrBatch(
+  imageUris: string[],
+  options?: OcrOptions,
+  onProgress?: (progress: number) => void,
+): Promise<OcrResult[]> {
+  const results: OcrResult[] = [];
+
+  for (let i = 0; i < imageUris.length; i++) {
+    const result = await performOcr(imageUris[i]!, options);
+    results.push(result);
+    onProgress?.((i + 1) / imageUris.length);
+  }
+
+  return results;
+}
+
+/**
+ * Extract plain text from an OCR result.
+ * Returns an empty string for error or no_text results.
+ */
+export function extractPlainText(result: OcrResult): string {
+  if (result.status === 'success') {
+    return result.data.text;
+  }
+  return '';
+}
+
+/**
+ * Extract all blocks with their bounding boxes from an OCR result.
+ * Returns an empty array for error or no_text results.
+ */
+export function extractBlocks(result: OcrResult): OcrBlock[] {
+  if (result.status === 'success') {
+    return result.data.blocks;
+  }
+  return [];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@infinitered/react-native-mlkit-document-scanner':
         specifier: ^5.0.0
         version: 5.0.0(expo-image@55.0.6(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@infinitered/react-native-mlkit-text-recognition':
+        specifier: ^5.0.1
+        version: 5.0.1(@types/react@19.2.14)(expo-image@55.0.6(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))
@@ -1060,6 +1063,14 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@infinitered/react-native-mlkit-core@3.1.0':
+    resolution: {integrity: sha512-W/EQB1EBMUHL1ZZ8bKV/T2TTNjMI+W2vlsx2T/+JXQRheiHpq73YbsDIC8kx8C0CJPXS/SZAWE3LnrR+6N7ELg==}
+    peerDependencies:
+      expo: '*'
+      expo-image: '*'
+      react: '*'
+      react-native: '*'
+
   '@infinitered/react-native-mlkit-core@5.0.0':
     resolution: {integrity: sha512-nss4q75/u8zMF4nhgsaO/MgBSO6WHfMAEE11yx7r7/LGTP12pRu6lOKgT8cGgVrmpsVlKjv7f4USeT2/wTMGVw==}
     peerDependencies:
@@ -1070,6 +1081,13 @@ packages:
 
   '@infinitered/react-native-mlkit-document-scanner@5.0.0':
     resolution: {integrity: sha512-sZEtUMK4QNpMpqz/3a1Xzt+Nh2GGKBxCMD0Bg7MNAvw2rPCvkekCMSkwvHn363OMLyoKkzrJ84FbFmy78VEgXQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
+  '@infinitered/react-native-mlkit-text-recognition@5.0.1':
+    resolution: {integrity: sha512-27uRVqzKvjkaSVOWgyF+lgwrPzF0tP0Y5StjM9tPHT7q+YFLxDdkdx18GzzixLEqIq5mLpa6nzU9iwNjEpnl3Q==}
     peerDependencies:
       expo: '*'
       react: '*'
@@ -1093,6 +1111,10 @@ packages:
 
   '@jest/environment@29.7.0':
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/fake-timers@29.7.0':
@@ -1611,6 +1633,34 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/jest-native@5.4.3':
+    resolution: {integrity: sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==}
+    deprecated: |-
+      DEPRECATED: This package is no longer maintained.
+      Please use the built-in Jest matchers available in @testing-library/react-native v12.4+.
+
+      See migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers
+    peerDependencies:
+      react: '>=16.0.0'
+      react-native: '>=0.59'
+      react-test-renderer: '>=16.0.0'
+
+  '@testing-library/react-hooks@8.0.1':
+    resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0
+      react: ^16.9.0 || ^17.0.0
+      react-dom: ^16.9.0 || ^17.0.0
+      react-test-renderer: ^16.9.0 || ^17.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1646,6 +1696,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -2159,6 +2212,10 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   dnssd-advertise@1.1.4:
     resolution: {integrity: sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==}
 
@@ -2276,6 +2333,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   expo-asset@55.0.10:
     resolution: {integrity: sha512-wxjNBKIaDyachq7oJgVlWVFzZ6SnNpJFJhkkcymXoTPt5O3XmDM+a6fT91xQQawCXTyZuCc1sNxKMetEofeYkg==}
@@ -2672,6 +2733,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -2741,6 +2806,10 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2751,6 +2820,10 @@ packages:
 
   jest-haste-map@29.7.0:
     resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-message-util@29.7.0:
@@ -3060,6 +3133,10 @@ packages:
     resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
     engines: {node: '>=4'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -3125,6 +3202,10 @@ packages:
   ob1@0.83.3:
     resolution: {integrity: sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA==}
     engines: {node: '>=20.19.4'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -3306,6 +3387,12 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
+  react-error-boundary@3.1.4:
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
@@ -3314,6 +3401,9 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       react: '>=17.0.0'
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -3374,6 +3464,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-shallow-renderer@16.15.0:
+    resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -3384,9 +3479,18 @@ packages:
       '@types/react':
         optional: true
 
+  react-test-renderer@17.0.2:
+    resolution: {integrity: sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==}
+    peerDependencies:
+      react: 17.0.2
+
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
@@ -3464,6 +3568,9 @@ packages:
   sax@1.5.0:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.20.2:
+    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3607,6 +3714,10 @@ packages:
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
@@ -5100,6 +5211,20 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@infinitered/react-native-mlkit-core@3.1.0(@types/react@19.2.14)(expo-image@55.0.6(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@testing-library/jest-native': 5.4.3(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)
+      '@testing-library/react-hooks': 8.0.1(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)
+      '@types/jest': 29.5.14
+      expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-image: 55.0.6(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+      - react-test-renderer
+
   '@infinitered/react-native-mlkit-core@5.0.0(expo-image@55.0.6(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -5115,6 +5240,18 @@ snapshots:
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - expo-image
+
+  '@infinitered/react-native-mlkit-text-recognition@5.0.1(@types/react@19.2.14)(expo-image@55.0.6(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@infinitered/react-native-mlkit-core': 3.1.0(@types/react@19.2.14)(expo-image@55.0.6(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(expo@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)
+      expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - expo-image
+      - react-dom
+      - react-test-renderer
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -5138,6 +5275,10 @@ snapshots:
       '@jest/types': 29.6.3
       '@types/node': 22.19.15
       jest-mock: 29.7.0
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
 
   '@jest/fake-timers@29.7.0':
     dependencies:
@@ -5679,6 +5820,27 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/jest-native@5.4.3(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-matcher-utils: 29.7.0
+      pretty-format: 29.7.0
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-test-renderer: 17.0.2(react@19.2.0)
+      redent: 3.0.0
+
+  '@testing-library/react-hooks@8.0.1(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react-test-renderer@17.0.2(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      react: 19.2.0
+      react-error-boundary: 3.1.4(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react-dom: 19.2.0(react@19.2.0)
+      react-test-renderer: 17.0.2(react@19.2.0)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -5727,6 +5889,11 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
 
   '@types/node@22.19.15':
     dependencies:
@@ -6343,6 +6510,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  diff-sequences@29.6.3: {}
+
   dnssd-advertise@1.1.4: {}
 
   doctrine@3.0.0:
@@ -6489,6 +6658,14 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   expect-type@1.3.0: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
 
   expo-asset@55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
@@ -6922,6 +7099,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -6984,6 +7163,13 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   jest-environment-node@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
@@ -7010,6 +7196,13 @@ snapshots:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
 
   jest-message-util@29.7.0:
     dependencies:
@@ -7409,6 +7602,8 @@ snapshots:
 
   mimic-fn@1.2.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -7455,6 +7650,8 @@ snapshots:
   ob1@0.83.3:
     dependencies:
       flow-enums-runtime: 0.0.6
+
+  object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
@@ -7631,11 +7828,18 @@ snapshots:
       react: 19.2.0
       scheduler: 0.27.0
 
+  react-error-boundary@3.1.4(react@19.2.0):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      react: 19.2.0
+
   react-fast-compare@3.2.2: {}
 
   react-freeze@1.0.4(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -7727,6 +7931,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  react-shallow-renderer@16.15.0(react@19.2.0):
+    dependencies:
+      object-assign: 4.1.1
+      react: 19.2.0
+      react-is: 18.3.1
+
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.0):
     dependencies:
       get-nonce: 1.0.1
@@ -7735,7 +7945,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  react-test-renderer@17.0.2(react@19.2.0):
+    dependencies:
+      object-assign: 4.1.1
+      react: 19.2.0
+      react-is: 17.0.2
+      react-shallow-renderer: 16.15.0(react@19.2.0)
+      scheduler: 0.20.2
+
   react@19.2.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   regenerate-unicode-properties@10.2.2:
     dependencies:
@@ -7820,6 +8043,11 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   sax@1.5.0: {}
+
+  scheduler@0.20.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
 
   scheduler@0.27.0: {}
 
@@ -7944,6 +8172,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- Adds OCR service wrapping `@infinitered/react-native-mlkit-text-recognition` for on-device text extraction
- Returns structured results: text blocks → lines → elements, each with bounding box coordinates
- Heuristic confidence scoring based on recognized language matching (English + Afrikaans hints)
- Batch processing support with progress callback for multi-page documents
- Platform guard for web (deferred to Phase 6 via tesseract.js)

## Changes
- `apps/mobile/src/services/ocr/ocrService.ts` — Core OCR service
- `apps/mobile/src/services/ocr/index.ts` — Barrel export
- `apps/mobile/package.json` — Added `@infinitered/react-native-mlkit-text-recognition`

## Test plan
- [ ] Call `performOcr(imageUri)` with a scanned document page → verify text blocks with bounding boxes returned
- [ ] Verify bounding boxes convert from ML Kit Rect (left/top/right/bottom) to BoundingBox (x/y/width/height)
- [ ] Verify confidence scores: ~0.9 for English/Afrikaans text, ~0.6 for no language detected
- [ ] Test `performOcrBatch` with multiple pages → verify progress callback fires
- [ ] Verify `extractPlainText` and `extractBlocks` helper functions
- [ ] Verify web platform returns error result gracefully
- [ ] Type-check passes, all 1448 existing tests pass

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)