### PR TITLE
feat(mobile): add platform-aware OCR abstraction (S-43)

### DIFF
--- a/apps/mobile/src/services/ocr/index.ts
+++ b/apps/mobile/src/services/ocr/index.ts
@@ -1,4 +1,13 @@
-export { performOcr, performOcrBatch, extractPlainText, extractBlocks } from './ocrService';
+// Public API
+export {
+  performOcr,
+  performOcrBatch,
+  extractPlainText,
+  extractBlocks,
+  getActiveProviderName,
+} from './ocrService';
+
+// Types (re-exported from types.ts for consumers)
 export type {
   OcrElement,
   OcrLine,
@@ -6,4 +15,5 @@ export type {
   OcrPageResult,
   OcrResult,
   OcrOptions,
-} from './ocrService';
+  OcrProvider,
+} from './types';

--- a/apps/mobile/src/services/ocr/mlkitProvider.ts
+++ b/apps/mobile/src/services/ocr/mlkitProvider.ts
@@ -1,0 +1,102 @@
+/**
+ * ML Kit OCR Provider (iOS/Android)
+ *
+ * Uses @infinitered/react-native-mlkit-text-recognition for on-device
+ * text recognition. Returns structured blocks with bounding boxes
+ * and heuristic confidence scores.
+ */
+
+import type { BoundingBox } from '@fillit/shared';
+
+import type { OcrBlock, OcrOptions, OcrProvider, OcrResult } from './types';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LANGUAGE_HINTS = ['en', 'af'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert ML Kit Rect (left/top/right/bottom) to BoundingBox (x/y/width/height). */
+function rectToBoundingBox(rect: {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}): BoundingBox {
+  return {
+    x: rect.left,
+    y: rect.top,
+    width: rect.right - rect.left,
+    height: rect.bottom - rect.top,
+  };
+}
+
+/**
+ * Estimate confidence based on recognized languages matching our hints.
+ * ML Kit doesn't expose per-block confidence directly.
+ */
+function estimateBlockConfidence(recognizedLanguages: string[], languageHints: string[]): number {
+  if (recognizedLanguages.length === 0) return 0.6;
+
+  const hintSet = new Set(languageHints);
+  const hasMatch = recognizedLanguages.some((lang) => hintSet.has(lang));
+  return hasMatch ? 0.9 : 0.7;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export const mlkitProvider: OcrProvider = {
+  name: 'mlkit',
+
+  async recognizePage(imageUri: string, options?: OcrOptions): Promise<OcrResult> {
+    const languageHints = options?.languageHints ?? DEFAULT_LANGUAGE_HINTS;
+    const startTime = Date.now();
+
+    try {
+      const { recognizeText } = await import('@infinitered/react-native-mlkit-text-recognition');
+      const result = await recognizeText(imageUri);
+
+      if (!result.text || result.text.trim().length === 0) {
+        return { status: 'no_text' };
+      }
+
+      const blocks: OcrBlock[] = result.blocks.map((block) => ({
+        text: block.text,
+        bounds: rectToBoundingBox(block.frame),
+        confidence: estimateBlockConfidence(block.recognizedLanguages, languageHints),
+        languages: block.recognizedLanguages,
+        lines: block.lines.map((line) => ({
+          text: line.text,
+          bounds: rectToBoundingBox(line.frame),
+          languages: line.recognizedLanguages,
+          elements: line.elements.map((element) => ({
+            text: element.text,
+            bounds: rectToBoundingBox(element.frame),
+            languages: element.recognizedLanguages,
+          })),
+        })),
+      }));
+
+      return {
+        status: 'success',
+        data: {
+          text: result.text,
+          blocks,
+          blockCount: blocks.length,
+          processingTimeMs: Date.now() - startTime,
+        },
+      };
+    } catch (error) {
+      return {
+        status: 'error',
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+  },
+};

--- a/apps/mobile/src/services/ocr/ocrService.ts
+++ b/apps/mobile/src/services/ocr/ocrService.ts
@@ -1,187 +1,48 @@
 /**
- * OCR Service (S-42)
+ * OCR Service — Platform-aware abstraction (S-42 + S-43)
  *
- * Wraps @infinitered/react-native-mlkit-text-recognition to provide
- * structured text extraction with bounding boxes and confidence scores.
- * Processes scanned document page images and returns hierarchical OCR
- * results (blocks → lines → elements) suitable for field detection.
- *
- * Platform support:
+ * Dispatches OCR operations to the appropriate provider based on platform:
  * - iOS/Android: ML Kit on-device text recognition
- * - Web: Not supported (will be added in Phase 6 via tesseract.js)
+ * - Web: Tesseract.js (stub — Phase 6)
+ *
+ * All providers conform to the OcrProvider interface and return the same
+ * consistent output format (OcrResult with blocks/lines/elements).
  */
 
 import { Platform } from 'react-native';
 
-import type { BoundingBox } from '@fillit/shared';
+import type { OcrBlock, OcrOptions, OcrProvider, OcrResult } from './types';
+import { mlkitProvider } from './mlkitProvider';
+import { webProvider } from './webProvider';
 
 // ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/** A recognized text element (word/number). */
-export interface OcrElement {
-  text: string;
-  bounds: BoundingBox;
-  languages: string[];
-}
-
-/** A recognized text line (row of elements). */
-export interface OcrLine {
-  text: string;
-  bounds: BoundingBox;
-  languages: string[];
-  elements: OcrElement[];
-}
-
-/** A recognized text block (paragraph/group of lines). */
-export interface OcrBlock {
-  text: string;
-  bounds: BoundingBox;
-  confidence: number;
-  languages: string[];
-  lines: OcrLine[];
-}
-
-/** Full OCR result for a single page. */
-export interface OcrPageResult {
-  /** The full extracted text from the page. */
-  text: string;
-  /** Structured text blocks with bounding boxes. */
-  blocks: OcrBlock[];
-  /** Number of text blocks found. */
-  blockCount: number;
-  /** Processing time in milliseconds. */
-  processingTimeMs: number;
-}
-
-/** Discriminated union for OCR outcomes. */
-export type OcrResult =
-  | { status: 'success'; data: OcrPageResult }
-  | { status: 'error'; error: Error }
-  | { status: 'no_text' };
-
-/** Options for OCR processing. */
-export interface OcrOptions {
-  /** Language hints to improve recognition accuracy. Defaults to ['en', 'af']. */
-  languageHints?: string[];
-}
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const DEFAULT_LANGUAGE_HINTS = ['en', 'af'];
-
-// ---------------------------------------------------------------------------
-// Helpers
+// Provider resolution
 // ---------------------------------------------------------------------------
 
 /**
- * Convert ML Kit Rect (left/top/right/bottom) to BoundingBox (x/y/width/height).
+ * Get the OCR provider for the current platform.
  */
-function rectToBoundingBox(rect: {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-}): BoundingBox {
-  return {
-    x: rect.left,
-    y: rect.top,
-    width: rect.right - rect.left,
-    height: rect.bottom - rect.top,
-  };
-}
-
-/**
- * Estimate confidence for a block based on recognized languages.
- *
- * ML Kit text recognition doesn't directly expose per-block confidence scores.
- * We derive a heuristic: blocks with recognized languages matching our hints
- * get higher confidence, blocks with unknown languages get lower confidence.
- */
-function estimateBlockConfidence(recognizedLanguages: string[], languageHints: string[]): number {
-  if (recognizedLanguages.length === 0) {
-    return 0.6; // No language detected — moderate confidence
+function getProvider(): OcrProvider {
+  if (Platform.OS === 'web') {
+    return webProvider;
   }
-
-  const hintSet = new Set(languageHints);
-  const matchCount = recognizedLanguages.filter((lang) => hintSet.has(lang)).length;
-
-  if (matchCount > 0) {
-    return 0.9; // Matches expected language — high confidence
-  }
-
-  return 0.7; // Recognized but unexpected language — moderate confidence
+  return mlkitProvider;
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Public API (backward-compatible with S-42)
 // ---------------------------------------------------------------------------
 
 /**
- * Perform OCR on a page image using ML Kit text recognition.
+ * Perform OCR on a page image using the platform-appropriate provider.
  *
  * @param imageUri - The local file URI of the page image (JPEG/PNG).
  * @param options - Optional OCR configuration.
  * @returns A discriminated result: success with structured text, no_text, or error.
  */
 export async function performOcr(imageUri: string, options?: OcrOptions): Promise<OcrResult> {
-  if (Platform.OS === 'web') {
-    return {
-      status: 'error',
-      error: new Error('OCR is not supported on web. Web OCR will be available in Phase 6.'),
-    };
-  }
-
-  const languageHints = options?.languageHints ?? DEFAULT_LANGUAGE_HINTS;
-  const startTime = Date.now();
-
-  try {
-    // Dynamic import to avoid bundling native module on web
-    const { recognizeText } = await import('@infinitered/react-native-mlkit-text-recognition');
-
-    const result = await recognizeText(imageUri);
-
-    if (!result.text || result.text.trim().length === 0) {
-      return { status: 'no_text' };
-    }
-
-    const blocks: OcrBlock[] = result.blocks.map((block) => ({
-      text: block.text,
-      bounds: rectToBoundingBox(block.frame),
-      confidence: estimateBlockConfidence(block.recognizedLanguages, languageHints),
-      languages: block.recognizedLanguages,
-      lines: block.lines.map((line) => ({
-        text: line.text,
-        bounds: rectToBoundingBox(line.frame),
-        languages: line.recognizedLanguages,
-        elements: line.elements.map((element) => ({
-          text: element.text,
-          bounds: rectToBoundingBox(element.frame),
-          languages: element.recognizedLanguages,
-        })),
-      })),
-    }));
-
-    const processingTimeMs = Date.now() - startTime;
-
-    return {
-      status: 'success',
-      data: {
-        text: result.text,
-        blocks,
-        blockCount: blocks.length,
-        processingTimeMs,
-      },
-    };
-  } catch (error) {
-    return {
-      status: 'error',
-      error: error instanceof Error ? error : new Error(String(error)),
-    };
-  }
+  const provider = getProvider();
+  return provider.recognizePage(imageUri, options);
 }
 
 /**
@@ -197,10 +58,11 @@ export async function performOcrBatch(
   options?: OcrOptions,
   onProgress?: (progress: number) => void,
 ): Promise<OcrResult[]> {
+  const provider = getProvider();
   const results: OcrResult[] = [];
 
   for (let i = 0; i < imageUris.length; i++) {
-    const result = await performOcr(imageUris[i]!, options);
+    const result = await provider.recognizePage(imageUris[i]!, options);
     results.push(result);
     onProgress?.((i + 1) / imageUris.length);
   }
@@ -228,4 +90,11 @@ export function extractBlocks(result: OcrResult): OcrBlock[] {
     return result.data.blocks;
   }
   return [];
+}
+
+/**
+ * Get the name of the active OCR provider for the current platform.
+ */
+export function getActiveProviderName(): string {
+  return getProvider().name;
 }

--- a/apps/mobile/src/services/ocr/types.ts
+++ b/apps/mobile/src/services/ocr/types.ts
@@ -1,0 +1,69 @@
+/**
+ * OCR type definitions shared across all platform providers.
+ *
+ * These types define the consistent output format that both the ML Kit
+ * (native) and Tesseract.js (web) providers must conform to.
+ */
+
+import type { BoundingBox } from '@fillit/shared';
+
+/** A recognized text element (word/number). */
+export interface OcrElement {
+  text: string;
+  bounds: BoundingBox;
+  languages: string[];
+}
+
+/** A recognized text line (row of elements). */
+export interface OcrLine {
+  text: string;
+  bounds: BoundingBox;
+  languages: string[];
+  elements: OcrElement[];
+}
+
+/** A recognized text block (paragraph/group of lines). */
+export interface OcrBlock {
+  text: string;
+  bounds: BoundingBox;
+  confidence: number;
+  languages: string[];
+  lines: OcrLine[];
+}
+
+/** Full OCR result for a single page. */
+export interface OcrPageResult {
+  /** The full extracted text from the page. */
+  text: string;
+  /** Structured text blocks with bounding boxes. */
+  blocks: OcrBlock[];
+  /** Number of text blocks found. */
+  blockCount: number;
+  /** Processing time in milliseconds. */
+  processingTimeMs: number;
+}
+
+/** Discriminated union for OCR outcomes. */
+export type OcrResult =
+  | { status: 'success'; data: OcrPageResult }
+  | { status: 'error'; error: Error }
+  | { status: 'no_text' };
+
+/** Options for OCR processing. */
+export interface OcrOptions {
+  /** Language hints to improve recognition accuracy. Defaults to ['en', 'af']. */
+  languageHints?: string[];
+}
+
+/**
+ * Platform-agnostic OCR provider interface.
+ *
+ * Each platform (native/web) implements this interface to provide
+ * consistent OCR capabilities regardless of the underlying engine.
+ */
+export interface OcrProvider {
+  /** Human-readable name for logging/debugging. */
+  readonly name: string;
+  /** Perform OCR on a single page image. */
+  recognizePage(imageUri: string, options?: OcrOptions): Promise<OcrResult>;
+}

--- a/apps/mobile/src/services/ocr/webProvider.ts
+++ b/apps/mobile/src/services/ocr/webProvider.ts
@@ -1,0 +1,21 @@
+/**
+ * Web OCR Provider (stub for Phase 6)
+ *
+ * Placeholder implementation for browser-based OCR via tesseract.js.
+ * Returns a descriptive error until the web platform is implemented.
+ */
+
+import type { OcrProvider, OcrResult } from './types';
+
+export const webProvider: OcrProvider = {
+  name: 'tesseract',
+
+  async recognizePage(): Promise<OcrResult> {
+    return {
+      status: 'error',
+      error: new Error(
+        'Web OCR is not yet implemented. Tesseract.js support will be added in Phase 6.',
+      ),
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- Refactors OCR service into a provider-based architecture for platform abstraction
- ML Kit provider handles native iOS/Android text recognition (extracted from S-42)
- Web provider stubs tesseract.js for Phase 6 with descriptive error
- Both providers conform to `OcrProvider` interface ensuring consistent output format
- Public API unchanged — backward compatible with existing consumers

## Changes
- `apps/mobile/src/services/ocr/types.ts` — Shared OCR types + `OcrProvider` interface
- `apps/mobile/src/services/ocr/mlkitProvider.ts` — ML Kit implementation
- `apps/mobile/src/services/ocr/webProvider.ts` — Tesseract.js stub (Phase 6)
- `apps/mobile/src/services/ocr/ocrService.ts` — Refactored to dispatch via provider
- `apps/mobile/src/services/ocr/index.ts` — Updated barrel exports

## Test plan
- [ ] `performOcr(imageUri)` still returns structured blocks with bounding boxes on native
- [ ] `performOcr(imageUri)` returns descriptive error on web
- [ ] `getActiveProviderName()` returns 'mlkit' on native, 'tesseract' on web
- [ ] `performOcrBatch` still works with progress callback
- [ ] Type-check passes, all 1448 existing tests pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)