### PR TITLE
feat(mobile): build OCR progress screen (S-44)

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -48,6 +48,7 @@ function RootNavigator() {
       <Stack.Screen name="profile/emergency/add" options={{ headerShown: false }} />
       <Stack.Screen name="profile/emergency/[id]" options={{ headerShown: false }} />
       <Stack.Screen name="scan/[id]" options={{ headerShown: false }} />
+      <Stack.Screen name="ocr/[id]" options={{ headerShown: false }} />
       <Stack.Screen name="__e2e" options={{ headerShown: true, headerTitle: 'E2E Tests' }} />
     </Stack>
   );

--- a/apps/mobile/app/ocr/[id].tsx
+++ b/apps/mobile/app/ocr/[id].tsx
@@ -1,0 +1,256 @@
+/**
+ * OCR Progress Screen (S-44)
+ *
+ * Displays real-time progress as each document page is processed
+ * through OCR. Shows per-page status (pending/processing/success/error),
+ * overall progress bar, and auto-advances to the next pipeline stage
+ * on completion.
+ */
+
+import React from 'react';
+import { ActivityIndicator, FlatList, StyleSheet, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+
+import { useTheme } from '../../src/theme';
+import {
+  Button,
+  BodyLarge,
+  BodyMedium,
+  BodySmall,
+  TitleLarge,
+  Card,
+} from '../../src/components/ui';
+import { ScreenHeader } from '../../src/components/profile/ScreenHeader';
+import {
+  useOcrProgress,
+  type PageOcrInfo,
+  type PageOcrStatus,
+} from '../../src/hooks/useOcrProgress';
+
+export default function OcrProgressScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { theme } = useTheme();
+
+  const { pages, progress, isProcessing, isComplete, cancel } = useOcrProgress({
+    documentId: id ?? '',
+    onComplete: () => {
+      // Auto-advance to home for now — field detection screen comes in Phase 3
+      setTimeout(() => {
+        router.replace('/(tabs)/home');
+      }, 1500);
+    },
+  });
+
+  const handleCancel = () => {
+    cancel();
+    router.back();
+  };
+
+  if (!id) {
+    return (
+      <View style={[styles.root, { backgroundColor: theme.colors.background }]}>
+        <ScreenHeader title="Processing" onBack={() => router.back()} />
+        <View style={styles.center}>
+          <BodyLarge color="secondary">No document ID provided.</BodyLarge>
+        </View>
+      </View>
+    );
+  }
+
+  const progressPercent = Math.round(progress * 100);
+  const completedCount = pages.filter(
+    (p) => p.status === 'success' || p.status === 'no_text',
+  ).length;
+  const errorCount = pages.filter((p) => p.status === 'error').length;
+
+  return (
+    <View
+      style={[styles.root, { backgroundColor: theme.colors.background }]}
+      testID="ocr-progress-screen"
+    >
+      <ScreenHeader title="Processing OCR" onBack={handleCancel} />
+
+      {/* Overall progress section */}
+      <View style={[styles.progressSection, { padding: theme.spacing.lg }]}>
+        <View style={styles.progressHeader}>
+          <TitleLarge>{isComplete ? 'Complete' : 'Extracting text...'}</TitleLarge>
+          <BodyLarge color="primary">{progressPercent}%</BodyLarge>
+        </View>
+
+        {/* Progress bar */}
+        <View
+          style={[
+            styles.progressTrack,
+            {
+              backgroundColor: theme.colors.surfaceVariant,
+              borderRadius: theme.radii.full,
+              marginTop: theme.spacing.sm,
+            },
+          ]}
+        >
+          <View
+            style={[
+              styles.progressFill,
+              {
+                backgroundColor: isComplete ? theme.colors.success : theme.colors.primary,
+                borderRadius: theme.radii.full,
+                width: `${progressPercent}%` as `${number}%`,
+              },
+            ]}
+          />
+        </View>
+
+        <BodySmall color="secondary" style={{ marginTop: theme.spacing.xs }}>
+          {completedCount} of {pages.length} pages processed
+          {errorCount > 0 ? ` (${errorCount} failed)` : ''}
+        </BodySmall>
+      </View>
+
+      {/* Per-page status list */}
+      <FlatList
+        data={pages}
+        keyExtractor={(page) => page.pageId}
+        contentContainerStyle={{ paddingHorizontal: theme.spacing.lg }}
+        renderItem={({ item }) => <PageStatusCard page={item} />}
+        ListEmptyComponent={
+          <View style={styles.center}>
+            <ActivityIndicator size="large" color={theme.colors.primary} />
+            <BodyMedium color="secondary" style={{ marginTop: theme.spacing.md }}>
+              Preparing pages...
+            </BodyMedium>
+          </View>
+        }
+      />
+
+      {/* Bottom actions */}
+      <View
+        style={[
+          styles.footer,
+          {
+            padding: theme.spacing.lg,
+            backgroundColor: theme.colors.surface,
+            borderTopWidth: 1,
+            borderTopColor: theme.colors.outline,
+          },
+        ]}
+      >
+        {isComplete ? (
+          <Button
+            label="Continue"
+            variant="primary"
+            size="lg"
+            fullWidth
+            onPress={() => router.replace('/(tabs)/home')}
+            testID="ocr-continue-button"
+          />
+        ) : (
+          <Button
+            label="Cancel"
+            variant="outline"
+            size="lg"
+            fullWidth
+            onPress={handleCancel}
+            disabled={!isProcessing}
+            testID="ocr-cancel-button"
+          />
+        )}
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page status card
+// ---------------------------------------------------------------------------
+
+function PageStatusCard({ page }: { page: PageOcrInfo }) {
+  const { theme } = useTheme();
+
+  return (
+    <Card elevation="none" bordered padding="md" style={{ marginBottom: theme.spacing.sm }}>
+      <View style={styles.pageRow}>
+        <StatusIcon status={page.status} />
+        <View style={[styles.pageInfo, { marginLeft: theme.spacing.md }]}>
+          <BodyMedium>Page {page.pageNumber}</BodyMedium>
+          {page.status === 'success' && page.textPreview ? (
+            <BodySmall color="secondary" numberOfLines={1}>
+              {page.textPreview}
+            </BodySmall>
+          ) : page.status === 'error' && page.error ? (
+            <BodySmall color="error" numberOfLines={1}>
+              {page.error}
+            </BodySmall>
+          ) : page.status === 'no_text' ? (
+            <BodySmall color="warning">No text detected</BodySmall>
+          ) : page.status === 'processing' ? (
+            <BodySmall color="secondary">Processing...</BodySmall>
+          ) : null}
+        </View>
+      </View>
+    </Card>
+  );
+}
+
+PageStatusCard.displayName = 'PageStatusCard';
+
+function StatusIcon({ status }: { status: PageOcrStatus }) {
+  const { theme } = useTheme();
+
+  switch (status) {
+    case 'processing':
+      return <ActivityIndicator size="small" color={theme.colors.primary} />;
+    case 'success':
+      return <Ionicons name="checkmark-circle" size={24} color={theme.colors.success} />;
+    case 'error':
+      return <Ionicons name="alert-circle" size={24} color={theme.colors.error} />;
+    case 'no_text':
+      return <Ionicons name="warning" size={24} color={theme.colors.warning} />;
+    default:
+      return <Ionicons name="ellipse-outline" size={24} color={theme.colors.outlineVariant} />;
+  }
+}
+
+StatusIcon.displayName = 'StatusIcon';
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 40,
+  },
+  progressSection: {
+    // padding applied via style prop
+  },
+  progressHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+  },
+  progressTrack: {
+    height: 8,
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+  },
+  footer: {
+    // padding applied via style prop
+  },
+  pageRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  pageInfo: {
+    flex: 1,
+  },
+});

--- a/apps/mobile/app/scan/[id].tsx
+++ b/apps/mobile/app/scan/[id].tsx
@@ -24,9 +24,8 @@ export default function ScanReviewScreen() {
   const { pages, isBusy, movePageUp, movePageDown, removePage, retakePage, confirm, canConfirm } =
     useScanReview({
       documentId: id ?? '',
-      onConfirm: () => {
-        // Navigate back to home for now — OCR screen comes in a later story
-        router.replace('/(tabs)/home');
+      onConfirm: (docId) => {
+        router.push(`/ocr/${docId}` as never);
       },
     });
 

--- a/apps/mobile/src/hooks/useOcrProgress.ts
+++ b/apps/mobile/src/hooks/useOcrProgress.ts
@@ -1,0 +1,211 @@
+/**
+ * Hook: useOcrProgress
+ *
+ * Orchestrates the OCR processing pipeline for a document:
+ *   1. Load document pages from the store
+ *   2. Run OCR on each page sequentially via performOcrBatch
+ *   3. Save OCR text to each page record in the database
+ *   4. Update processing store progress in real time
+ *   5. Advance pipeline to the detecting stage on completion
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useDocumentStore, selectDocumentById } from '../stores/document-store';
+import { useProcessingStore } from '../stores/processing-store';
+import { performOcr, extractPlainText } from '../services/ocr';
+import type { OcrResult } from '../services/ocr';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PageOcrStatus = 'pending' | 'processing' | 'success' | 'error' | 'no_text';
+
+export interface PageOcrInfo {
+  pageId: string;
+  pageNumber: number;
+  status: PageOcrStatus;
+  textPreview?: string;
+  error?: string;
+}
+
+export interface UseOcrProgressOptions {
+  documentId: string;
+  /** Auto-start OCR when the hook mounts. @default true */
+  autoStart?: boolean;
+  onComplete?: (documentId: string) => void;
+}
+
+export interface UseOcrProgressReturn {
+  /** Per-page OCR status information. */
+  pages: PageOcrInfo[];
+  /** Overall progress from 0 to 1. */
+  progress: number;
+  /** Whether OCR is currently running. */
+  isProcessing: boolean;
+  /** Whether all pages have been processed. */
+  isComplete: boolean;
+  /** Start or restart OCR processing. */
+  start: () => Promise<void>;
+  /** Cancel the current OCR run. */
+  cancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useOcrProgress({
+  documentId,
+  autoStart = true,
+  onComplete,
+}: UseOcrProgressOptions): UseOcrProgressReturn {
+  const [pageInfos, setPageInfos] = useState<PageOcrInfo[]>([]);
+  const [progress, setProgress] = useState(0);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const cancelledRef = useRef(false);
+  const startedRef = useRef(false);
+
+  const document = useDocumentStore(selectDocumentById(documentId));
+  const updatePage = useDocumentStore((s) => s.updatePage);
+  const updateStatus = useDocumentStore((s) => s.updateStatus);
+  const updateProgress = useProcessingStore((s) => s.updateProgress);
+  const completeCurrentStage = useProcessingStore((s) => s.completeCurrentStage);
+  const advanceStage = useProcessingStore((s) => s.advanceStage);
+
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
+  const pages = document?.pages
+    ? [...document.pages].sort((a, b) => a.pageNumber - b.pageNumber)
+    : [];
+
+  const start = useCallback(async () => {
+    if (isProcessing || pages.length === 0) return;
+
+    cancelledRef.current = false;
+    setIsProcessing(true);
+    setIsComplete(false);
+    setProgress(0);
+
+    // Initialize page statuses
+    const initialInfos: PageOcrInfo[] = pages.map((p) => ({
+      pageId: p.id,
+      pageNumber: p.pageNumber,
+      status: 'pending' as PageOcrStatus,
+    }));
+    setPageInfos(initialInfos);
+
+    let successCount = 0;
+
+    for (let i = 0; i < pages.length; i++) {
+      if (cancelledRef.current) break;
+
+      const page = pages[i]!;
+      const imageUri = page.processedImageUri ?? page.originalImageUri;
+
+      // Mark current page as processing
+      setPageInfos((prev) =>
+        prev.map((p) => (p.pageId === page.id ? { ...p, status: 'processing' } : p)),
+      );
+
+      let result: OcrResult;
+      try {
+        result = await performOcr(imageUri);
+      } catch (error) {
+        result = {
+          status: 'error',
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+
+      if (cancelledRef.current) break;
+
+      // Update page info based on result
+      const text = extractPlainText(result);
+      const preview = text.slice(0, 100);
+
+      if (result.status === 'success') {
+        successCount++;
+        setPageInfos((prev) =>
+          prev.map((p) =>
+            p.pageId === page.id ? { ...p, status: 'success', textPreview: preview } : p,
+          ),
+        );
+        // Persist OCR text to database
+        try {
+          await updatePage(page.id, { ocrText: text }, documentId);
+        } catch {
+          // DB write failure is non-fatal for the progress screen
+        }
+      } else if (result.status === 'no_text') {
+        setPageInfos((prev) =>
+          prev.map((p) => (p.pageId === page.id ? { ...p, status: 'no_text' } : p)),
+        );
+        // Still save empty text
+        try {
+          await updatePage(page.id, { ocrText: '' }, documentId);
+        } catch {
+          // Non-fatal
+        }
+      } else {
+        setPageInfos((prev) =>
+          prev.map((p) =>
+            p.pageId === page.id ? { ...p, status: 'error', error: result.error.message } : p,
+          ),
+        );
+      }
+
+      const newProgress = (i + 1) / pages.length;
+      setProgress(newProgress);
+      updateProgress(newProgress);
+    }
+
+    if (!cancelledRef.current) {
+      // Advance pipeline
+      try {
+        await updateStatus(documentId, 'ocr_complete');
+      } catch {
+        // Status update failure is non-fatal
+      }
+      completeCurrentStage();
+      advanceStage();
+      setIsComplete(true);
+      onCompleteRef.current?.(documentId);
+    }
+
+    setIsProcessing(false);
+  }, [
+    isProcessing,
+    pages,
+    documentId,
+    updatePage,
+    updateStatus,
+    updateProgress,
+    completeCurrentStage,
+    advanceStage,
+  ]);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+  }, []);
+
+  // Auto-start on mount
+  useEffect(() => {
+    if (autoStart && !startedRef.current && pages.length > 0) {
+      startedRef.current = true;
+      void start();
+    }
+  }, [autoStart, pages.length, start]);
+
+  return {
+    pages: pageInfos,
+    progress,
+    isProcessing,
+    isComplete,
+    start,
+    cancel,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds OCR progress screen showing real-time per-page processing status
- Displays overall progress bar with percentage, per-page cards with status icons
- Text preview shown for successfully OCR'd pages, error messages for failures
- Auto-advances pipeline to detecting stage and navigates home on completion
- Cancel button allows aborting OCR mid-process
- Updated scan review screen to navigate to OCR screen instead of home

## Changes
- `apps/mobile/app/ocr/[id].tsx` — New OCR progress screen
- `apps/mobile/src/hooks/useOcrProgress.ts` — OCR orchestration hook
- `apps/mobile/app/_layout.tsx` — Registered `ocr/[id]` route
- `apps/mobile/app/scan/[id].tsx` — Navigate to OCR screen on confirm

## Test plan
- [ ] Confirm scan review → verify navigation to OCR progress screen
- [ ] Verify pages show pending → processing → success/error transitions
- [ ] Verify overall progress bar updates after each page completes
- [ ] Verify OCR text is persisted to document pages in SQLite
- [ ] Verify auto-advance to home after completion (1.5s delay)
- [ ] Test Cancel button → verify OCR stops and navigates back
- [ ] Verify document status updates to 'ocr_complete' on success
- [ ] Type-check passes, all 1448 existing tests pass

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)