### PR TITLE
feat(mobile): add drawn signature canvas and typed signature (S-68, S-69)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -48,6 +48,7 @@
     "react-native-reanimated": "^4.3.0",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",
+    "react-native-svg": "15.15.3",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/apps/mobile/src/components/signature/SignaturePad.tsx
+++ b/apps/mobile/src/components/signature/SignaturePad.tsx
@@ -1,0 +1,294 @@
+/**
+ * Freehand signature drawing canvas.
+ *
+ * Uses react-native-gesture-handler for touch tracking and
+ * react-native-svg for smooth vector rendering. Captures strokes
+ * as SVG path data strings for compact, resolution-independent storage.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
+import Svg, { Path } from 'react-native-svg';
+
+import { useTheme } from '../../theme';
+import { Button } from '../ui/Button';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+/** A single continuous stroke captured from a finger gesture. */
+interface Stroke {
+  /** SVG path data string (e.g. "M 10 20 L 30 40 ..."). */
+  path: string;
+  /** Stroke color. */
+  color: string;
+  /** Stroke width in pixels. */
+  width: number;
+}
+
+/** Result returned when the user saves their drawn signature. */
+export interface SignaturePadResult {
+  /** Combined SVG path data for all strokes. */
+  svgPath: string;
+  /** Stroke color used. */
+  color: string;
+  /** Stroke width used. */
+  strokeWidth: number;
+}
+
+export interface SignaturePadProps {
+  /** Canvas height in dp. @default 200 */
+  height?: number;
+  /** Initial stroke color. @default theme.colors.onSurface */
+  strokeColor?: string;
+  /** Initial stroke width. @default 2.5 */
+  strokeWidth?: number;
+  /** Available stroke widths for the picker. */
+  strokeWidths?: number[];
+  /** Available stroke colors for the picker. */
+  strokeColors?: string[];
+  /** Called when the user taps Save with a non-empty signature. */
+  onSave?: (result: SignaturePadResult) => void;
+  /** Called when the user taps Cancel. */
+  onCancel?: () => void;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function buildPathData(points: Array<{ x: number; y: number }>): string {
+  if (points.length === 0) return '';
+  const [first, ...rest] = points;
+  let d = `M ${first!.x.toFixed(1)} ${first!.y.toFixed(1)}`;
+  for (const p of rest) {
+    d += ` L ${p.x.toFixed(1)} ${p.y.toFixed(1)}`;
+  }
+  return d;
+}
+
+// ─── Component ─────────────────────────────────────────────────────
+
+const DEFAULT_WIDTHS = [1.5, 2.5, 4];
+const DEFAULT_COLORS = ['#000000', '#1A237E', '#1B5E20'];
+
+export function SignaturePad({
+  height = 200,
+  strokeColor,
+  strokeWidth = 2.5,
+  strokeWidths = DEFAULT_WIDTHS,
+  strokeColors = DEFAULT_COLORS,
+  onSave,
+  onCancel,
+}: SignaturePadProps) {
+  const { theme } = useTheme();
+  const defaultColor = strokeColor ?? theme.colors.onSurface;
+
+  const [strokes, setStrokes] = useState<Stroke[]>([]);
+  const [activeColor, setActiveColor] = useState(defaultColor);
+  const [activeWidth, setActiveWidth] = useState(strokeWidth);
+  const currentPoints = useRef<Array<{ x: number; y: number }>>([]);
+
+  const isEmpty = strokes.length === 0;
+
+  const handleClear = useCallback(() => {
+    setStrokes([]);
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    setStrokes((prev) => prev.slice(0, -1));
+  }, []);
+
+  const handleSave = useCallback(() => {
+    if (isEmpty || !onSave) return;
+    const svgPath = strokes.map((s) => s.path).join(' ');
+    onSave({ svgPath, color: activeColor, strokeWidth: activeWidth });
+  }, [isEmpty, strokes, activeColor, activeWidth, onSave]);
+
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .minDistance(0)
+        .onBegin((e) => {
+          currentPoints.current = [{ x: e.x, y: e.y }];
+        })
+        .onUpdate((e) => {
+          currentPoints.current.push({ x: e.x, y: e.y });
+        })
+        .onEnd(() => {
+          const path = buildPathData(currentPoints.current);
+          if (path) {
+            setStrokes((prev) => [...prev, { path, color: activeColor, width: activeWidth }]);
+          }
+          currentPoints.current = [];
+        }),
+    [activeColor, activeWidth],
+  );
+
+  return (
+    <View testID="signature-pad">
+      {/* Canvas */}
+      <GestureHandlerRootView>
+        <GestureDetector gesture={panGesture}>
+          <View
+            style={[
+              styles.canvas,
+              {
+                height,
+                backgroundColor: theme.colors.surface,
+                borderColor: theme.colors.outline,
+                borderRadius: theme.radii.md,
+              },
+            ]}
+            testID="signature-pad-canvas"
+          >
+            <Svg width="100%" height="100%">
+              {strokes.map((stroke, i) => (
+                <Path
+                  key={i}
+                  d={stroke.path}
+                  stroke={stroke.color}
+                  strokeWidth={stroke.width}
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              ))}
+            </Svg>
+          </View>
+        </GestureDetector>
+      </GestureHandlerRootView>
+
+      {/* Toolbar: color + width pickers */}
+      <View style={[styles.toolbar, { marginTop: theme.spacing.sm }]}>
+        {/* Color picker */}
+        <View style={styles.pickerRow}>
+          {strokeColors.map((color) => (
+            <View
+              key={color}
+              style={[
+                styles.colorSwatch,
+                {
+                  backgroundColor: color,
+                  borderColor: color === activeColor ? theme.colors.primary : 'transparent',
+                  borderWidth: color === activeColor ? 2.5 : 0,
+                },
+              ]}
+              onTouchEnd={() => setActiveColor(color)}
+              accessibilityRole="button"
+              accessibilityLabel={`Pen color ${color}`}
+              accessibilityState={{ selected: color === activeColor }}
+              testID={`signature-pad-color-${color}`}
+            />
+          ))}
+        </View>
+
+        {/* Width picker */}
+        <View style={styles.pickerRow}>
+          {strokeWidths.map((w) => (
+            <View
+              key={w}
+              style={[
+                styles.widthOption,
+                {
+                  borderColor: w === activeWidth ? theme.colors.primary : theme.colors.outline,
+                  borderWidth: w === activeWidth ? 2 : 1,
+                  borderRadius: theme.radii.sm,
+                },
+              ]}
+              onTouchEnd={() => setActiveWidth(w)}
+              accessibilityRole="button"
+              accessibilityLabel={`Pen width ${w}`}
+              accessibilityState={{ selected: w === activeWidth }}
+              testID={`signature-pad-width-${w}`}
+            >
+              <View
+                style={{
+                  width: 24,
+                  height: w,
+                  backgroundColor: activeColor,
+                  borderRadius: w / 2,
+                }}
+              />
+            </View>
+          ))}
+        </View>
+      </View>
+
+      {/* Actions */}
+      <View style={[styles.actions, { marginTop: theme.spacing.md }]}>
+        <Button
+          label="Clear"
+          variant="ghost"
+          size="sm"
+          onPress={handleClear}
+          disabled={isEmpty}
+          testID="signature-pad-clear"
+          style={{ marginRight: theme.spacing.sm }}
+        />
+        <Button
+          label="Undo"
+          variant="outline"
+          size="sm"
+          onPress={handleUndo}
+          disabled={isEmpty}
+          testID="signature-pad-undo"
+          style={{ marginRight: theme.spacing.sm }}
+        />
+        {onCancel ? (
+          <Button
+            label="Cancel"
+            variant="outline"
+            size="sm"
+            onPress={onCancel}
+            testID="signature-pad-cancel"
+            style={{ marginRight: theme.spacing.sm }}
+          />
+        ) : null}
+        <Button
+          label="Save"
+          variant="primary"
+          size="sm"
+          onPress={handleSave}
+          disabled={isEmpty}
+          testID="signature-pad-save"
+          style={{ flex: 1 }}
+        />
+      </View>
+    </View>
+  );
+}
+
+// ─── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  canvas: {
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  toolbar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  pickerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  colorSwatch: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+  },
+  widthOption: {
+    width: 40,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+
+SignaturePad.displayName = 'SignaturePad';

--- a/apps/mobile/src/components/signature/TypedSignature.tsx
+++ b/apps/mobile/src/components/signature/TypedSignature.tsx
@@ -1,0 +1,212 @@
+/**
+ * Typed signature component.
+ *
+ * Lets the user type their name and choose from signature-style fonts.
+ * Shows a live preview of the typed text in the selected font.
+ */
+
+import { useCallback, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { useTheme } from '../../theme';
+import { FontCategories, FontFamily } from '../../fonts/config';
+import { Button } from '../ui/Button';
+import { TextInput } from '../ui/TextInput';
+import { Chip } from '../ui/Badge';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+/** A signature font option shown in the picker. */
+export interface SignatureFont {
+  /** Font family name (matches a loaded font). */
+  family: string;
+  /** Display label for the picker. */
+  label: string;
+}
+
+/** Result returned when the user saves a typed signature. */
+export interface TypedSignatureResult {
+  /** The typed text (e.g. the user's name). */
+  text: string;
+  /** The selected font family name. */
+  fontFamily: string;
+}
+
+export interface TypedSignatureProps {
+  /** Initial text value. */
+  initialText?: string;
+  /** Initial font family. */
+  initialFont?: string;
+  /** Override the available signature fonts. */
+  fonts?: SignatureFont[];
+  /** Preview area height in dp. @default 100 */
+  previewHeight?: number;
+  /** Called when the user saves the typed signature. */
+  onSave?: (result: TypedSignatureResult) => void;
+  /** Called when the user cancels. */
+  onCancel?: () => void;
+}
+
+// ─── Default Fonts ─────────────────────────────────────────────────
+
+const DEFAULT_FONTS: SignatureFont[] = [
+  { family: FontCategories.signature.dancingScript, label: 'Script' },
+  { family: FontCategories.signature.greatVibes, label: 'Elegant' },
+  { family: FontFamily.InterRegular, label: 'Print' },
+];
+
+// ─── Component ─────────────────────────────────────────────────────
+
+export function TypedSignature({
+  initialText = '',
+  initialFont,
+  fonts = DEFAULT_FONTS,
+  previewHeight = 100,
+  onSave,
+  onCancel,
+}: TypedSignatureProps) {
+  const { theme } = useTheme();
+  const [text, setText] = useState(initialText);
+  const [selectedFont, setSelectedFont] = useState(
+    initialFont ?? fonts[0]?.family ?? FontFamily.InterRegular,
+  );
+
+  const isEmpty = text.trim().length === 0;
+
+  const handleSave = useCallback(() => {
+    if (isEmpty || !onSave) return;
+    onSave({ text: text.trim(), fontFamily: selectedFont });
+  }, [isEmpty, text, selectedFont, onSave]);
+
+  return (
+    <View testID="typed-signature">
+      {/* Text input */}
+      <TextInput
+        label="Your name"
+        value={text}
+        onChangeText={setText}
+        placeholder="Type your name"
+        variant="outlined"
+        autoCapitalize="words"
+        testID="typed-signature-input"
+      />
+
+      {/* Font selector */}
+      <View style={styles.fontRow}>
+        <Text
+          style={[
+            theme.typography.labelMedium,
+            {
+              color: theme.colors.onSurfaceVariant,
+              marginBottom: theme.spacing.sm,
+            },
+          ]}
+        >
+          Font style
+        </Text>
+        <View style={styles.fontChips}>
+          {fonts.map((font) => (
+            <Chip
+              key={font.family}
+              label={font.label}
+              variant={selectedFont === font.family ? 'filled' : 'outlined'}
+              color={selectedFont === font.family ? 'primary' : 'default'}
+              selected={selectedFont === font.family}
+              onPress={() => setSelectedFont(font.family)}
+              style={{ marginRight: theme.spacing.sm }}
+            />
+          ))}
+        </View>
+      </View>
+
+      {/* Live preview */}
+      <View
+        style={[
+          styles.preview,
+          {
+            height: previewHeight,
+            backgroundColor: theme.colors.surface,
+            borderColor: theme.colors.outline,
+            borderRadius: theme.radii.md,
+          },
+        ]}
+        testID="typed-signature-preview"
+      >
+        {text.trim() ? (
+          <Text
+            style={[
+              styles.previewText,
+              {
+                fontFamily: selectedFont,
+                color: theme.colors.onSurface,
+              },
+            ]}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+          >
+            {text}
+          </Text>
+        ) : (
+          <Text
+            style={[
+              theme.typography.bodyMedium,
+              { color: theme.colors.onSurfaceVariant, fontStyle: 'italic' },
+            ]}
+          >
+            Signature preview
+          </Text>
+        )}
+      </View>
+
+      {/* Actions */}
+      <View style={[styles.actions, { marginTop: theme.spacing.md }]}>
+        {onCancel ? (
+          <Button
+            label="Cancel"
+            variant="outline"
+            size="sm"
+            onPress={onCancel}
+            testID="typed-signature-cancel"
+            style={{ marginRight: theme.spacing.sm }}
+          />
+        ) : null}
+        <Button
+          label="Save"
+          variant="primary"
+          size="sm"
+          onPress={handleSave}
+          disabled={isEmpty}
+          testID="typed-signature-save"
+          style={{ flex: 1 }}
+        />
+      </View>
+    </View>
+  );
+}
+
+// ─── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  fontRow: {
+    marginBottom: 12,
+  },
+  fontChips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  preview: {
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+  },
+  previewText: {
+    fontSize: 36,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+
+TypedSignature.displayName = 'TypedSignature';

--- a/apps/mobile/src/components/signature/__tests__/SignaturePad.test.ts
+++ b/apps/mobile/src/components/signature/__tests__/SignaturePad.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the SignaturePad component.
+ *
+ * Verifies exports, type contracts, and helper function behavior.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type * as SignaturePadModule from '../SignaturePad';
+import type { SignaturePadResult } from '../SignaturePad';
+
+// ─── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  StyleSheet: {
+    create: (s: Record<string, unknown>) => s,
+    flatten: (s: unknown) => s,
+  },
+  Text: 'Text',
+  View: 'View',
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  GestureDetector: 'GestureDetector',
+  GestureHandlerRootView: 'GestureHandlerRootView',
+  Gesture: {
+    Pan: vi.fn(() => ({
+      minDistance: vi.fn().mockReturnThis(),
+      onBegin: vi.fn().mockReturnThis(),
+      onUpdate: vi.fn().mockReturnThis(),
+      onEnd: vi.fn().mockReturnThis(),
+    })),
+  },
+}));
+
+vi.mock('react-native-svg', () => ({
+  default: 'Svg',
+  Path: 'Path',
+}));
+
+vi.mock('../../../theme', async () => {
+  const { lightTheme } = await import('../../../theme/themes');
+  return {
+    useTheme: () => ({
+      theme: lightTheme,
+      isDark: false,
+      colorMode: 'system' as const,
+      resolvedColorScheme: 'light' as const,
+      setColorMode: () => {},
+      toggleColorMode: () => {},
+    }),
+  };
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe('SignaturePad', () => {
+  let mod: typeof SignaturePadModule;
+
+  beforeAll(async () => {
+    mod = await import('../SignaturePad');
+  });
+
+  describe('module exports', () => {
+    it('should export the SignaturePad component', () => {
+      expect(mod.SignaturePad).toBeDefined();
+      expect(typeof mod.SignaturePad).toBe('function');
+    });
+
+    it('should have displayName set', () => {
+      expect(mod.SignaturePad.displayName).toBe('SignaturePad');
+    });
+  });
+
+  describe('SignaturePadResult type', () => {
+    it('should satisfy the interface with all required fields', () => {
+      const result: SignaturePadResult = {
+        svgPath: 'M 10.0 20.0 L 30.0 40.0',
+        color: '#000000',
+        strokeWidth: 2.5,
+      };
+      expect(result.svgPath).toContain('M');
+      expect(result.color).toBe('#000000');
+      expect(result.strokeWidth).toBe(2.5);
+    });
+
+    it('should support multiple stroke paths concatenated', () => {
+      const result: SignaturePadResult = {
+        svgPath: 'M 0.0 0.0 L 10.0 10.0 M 20.0 20.0 L 30.0 30.0',
+        color: '#1A237E',
+        strokeWidth: 4,
+      };
+      expect(result.svgPath.split('M').length).toBe(3); // 2 strokes + leading empty
+    });
+  });
+});
+
+vi.mock('../../../fonts/config', () => ({
+  FontFamily: {
+    InterRegular: 'Inter-Regular',
+    InterMedium: 'Inter-Medium',
+    InterSemiBold: 'Inter-SemiBold',
+    InterBold: 'Inter-Bold',
+    JetBrainsMonoRegular: 'JetBrainsMono-Regular',
+    DancingScriptRegular: 'DancingScript-Regular',
+    GreatVibesRegular: 'GreatVibes-Regular',
+  },
+  FontCategories: {
+    signature: {
+      dancingScript: 'DancingScript-Regular',
+      greatVibes: 'GreatVibes-Regular',
+    },
+  },
+}));
+
+describe('signature barrel export', () => {
+  it('should re-export SignaturePad from index', async () => {
+    const index = await import('../index');
+    expect(index.SignaturePad).toBeDefined();
+    expect(typeof index.SignaturePad).toBe('function');
+  });
+});

--- a/apps/mobile/src/components/signature/__tests__/TypedSignature.test.ts
+++ b/apps/mobile/src/components/signature/__tests__/TypedSignature.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the TypedSignature component.
+ *
+ * Verifies exports, type contracts, and default font configuration.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type * as TypedSignatureModule from '../TypedSignature';
+import type { TypedSignatureResult, SignatureFont } from '../TypedSignature';
+
+// ─── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  StyleSheet: {
+    create: (s: Record<string, unknown>) => s,
+    flatten: (s: unknown) => s,
+  },
+  Text: 'Text',
+  View: 'View',
+  TextInput: 'TextInput',
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  GestureDetector: 'GestureDetector',
+  GestureHandlerRootView: 'GestureHandlerRootView',
+  Gesture: {
+    Pan: vi.fn(() => ({
+      minDistance: vi.fn().mockReturnThis(),
+      onBegin: vi.fn().mockReturnThis(),
+      onUpdate: vi.fn().mockReturnThis(),
+      onEnd: vi.fn().mockReturnThis(),
+    })),
+  },
+}));
+
+vi.mock('react-native-svg', () => ({
+  default: 'Svg',
+  Path: 'Path',
+}));
+
+vi.mock('../../../fonts/config', () => ({
+  FontFamily: {
+    InterRegular: 'Inter-Regular',
+    InterMedium: 'Inter-Medium',
+    InterSemiBold: 'Inter-SemiBold',
+    InterBold: 'Inter-Bold',
+    JetBrainsMonoRegular: 'JetBrainsMono-Regular',
+    DancingScriptRegular: 'DancingScript-Regular',
+    GreatVibesRegular: 'GreatVibes-Regular',
+  },
+  FontCategories: {
+    signature: {
+      dancingScript: 'DancingScript-Regular',
+      greatVibes: 'GreatVibes-Regular',
+    },
+  },
+}));
+
+vi.mock('../../../theme', async () => {
+  const { lightTheme } = await import('../../../theme/themes');
+  return {
+    useTheme: () => ({
+      theme: lightTheme,
+      isDark: false,
+      colorMode: 'system' as const,
+      resolvedColorScheme: 'light' as const,
+      setColorMode: () => {},
+      toggleColorMode: () => {},
+    }),
+  };
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe('TypedSignature', () => {
+  let mod: typeof TypedSignatureModule;
+
+  beforeAll(async () => {
+    mod = await import('../TypedSignature');
+  });
+
+  describe('module exports', () => {
+    it('should export the TypedSignature component', () => {
+      expect(mod.TypedSignature).toBeDefined();
+      expect(typeof mod.TypedSignature).toBe('function');
+    });
+
+    it('should have displayName set', () => {
+      expect(mod.TypedSignature.displayName).toBe('TypedSignature');
+    });
+  });
+
+  describe('TypedSignatureResult type', () => {
+    it('should satisfy the interface with text and font', () => {
+      const result: TypedSignatureResult = {
+        text: 'John Smith',
+        fontFamily: 'DancingScript-Regular',
+      };
+      expect(result.text).toBe('John Smith');
+      expect(result.fontFamily).toBe('DancingScript-Regular');
+    });
+
+    it('should allow different font families', () => {
+      const results: TypedSignatureResult[] = [
+        { text: 'Jane', fontFamily: 'DancingScript-Regular' },
+        { text: 'Jane', fontFamily: 'GreatVibes-Regular' },
+        { text: 'Jane', fontFamily: 'Inter-Regular' },
+      ];
+      const families = new Set(results.map((r) => r.fontFamily));
+      expect(families.size).toBe(3);
+    });
+  });
+
+  describe('SignatureFont type', () => {
+    it('should have family and label fields', () => {
+      const font: SignatureFont = {
+        family: 'DancingScript-Regular',
+        label: 'Script',
+      };
+      expect(font.family).toBe('DancingScript-Regular');
+      expect(font.label).toBe('Script');
+    });
+  });
+});
+
+describe('signature barrel export', () => {
+  it('should re-export TypedSignature from index', async () => {
+    const index = await import('../index');
+    expect(index.TypedSignature).toBeDefined();
+    expect(typeof index.TypedSignature).toBe('function');
+  });
+});

--- a/apps/mobile/src/components/signature/index.ts
+++ b/apps/mobile/src/components/signature/index.ts
@@ -1,0 +1,4 @@
+export { SignaturePad } from './SignaturePad';
+export type { SignaturePadProps, SignaturePadResult } from './SignaturePad';
+export { TypedSignature } from './TypedSignature';
+export type { TypedSignatureProps, TypedSignatureResult, SignatureFont } from './TypedSignature';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       react-native-screens:
         specifier: ~4.23.0
         version: 4.23.0(react-native@0.83.2(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react-native-svg:
+        specifier: 15.15.3
+        version: 15.15.3(react-native@0.83.2(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
@@ -2036,6 +2039,9 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
 
@@ -2190,6 +2196,17 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2258,6 +2275,19 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2274,6 +2304,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -3068,6 +3102,9 @@ packages:
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -3223,6 +3260,9 @@ packages:
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -3462,6 +3502,12 @@ packages:
 
   react-native-screens@4.23.0:
     resolution: {integrity: sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-svg@15.15.3:
+    resolution: {integrity: sha512-/k4KYwPBLGcx2f5d4FjE+vCScK7QOX14cl2lIASJ28u4slHHtIhL0SZKU7u9qmRBHxTCKPoPBtN6haT1NENJNA==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -5827,7 +5873,9 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.83.2': {}
 
@@ -6429,6 +6477,8 @@ snapshots:
 
   big-integer@1.6.52: {}
 
+  boolbase@1.0.0: {}
+
   bplist-creator@0.1.0:
     dependencies:
       stream-buffers: 2.2.0
@@ -6598,6 +6648,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
+  css-what@6.2.2: {}
+
   csstype@3.2.3: {}
 
   debug@2.6.9:
@@ -6638,6 +6703,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.313: {}
@@ -6647,6 +6730,8 @@ snapshots:
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
+
+  entities@4.5.0: {}
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -7508,6 +7593,8 @@ snapshots:
 
   marky@1.3.0: {}
 
+  mdn-data@2.0.14: {}
+
   memoize-one@5.2.1: {}
 
   merge-options@3.0.4:
@@ -7754,6 +7841,10 @@ snapshots:
       semver: 7.7.4
       validate-npm-package-name: 5.0.1
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   nullthrows@1.1.1: {}
 
   ob1@0.83.3:
@@ -7982,6 +8073,14 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-freeze: 1.0.4(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+      warn-once: 0.1.1
+
+  react-native-svg@15.15.3(react-native@0.83.2(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.2.0
       react-native: 0.83.2(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
       warn-once: 0.1.1
 


### PR DESCRIPTION
## Summary
- **S-68: SignaturePad** — freehand drawing canvas using `react-native-svg` + `react-native-gesture-handler`. Pen color picker (3 colors), stroke width picker (3 widths), clear/undo, and SVG path data export
- **S-69: TypedSignature** — name input with font selector (Dancing Script, Great Vibes, Print), live preview with auto-sizing, and text+font export
- New dependency: `react-native-svg` 15.15.3 (Expo-compatible)

Closes #69
Closes #70

## Acceptance Criteria

### S-68: Drawn Signature Canvas
- [x] Signature canvas with smooth drawing (gesture-handler Pan + SVG Path)
- [x] Adjustable pen thickness and color (3 widths, 3 colors)
- [x] Clear/undo functionality
- [x] Save as SVG path data
- [x] Preview before saving (live SVG rendering)

### S-69: Typed Signature Component
- [x] Text input for name
- [x] Font selector (3 signature fonts)
- [x] Live preview (auto-sizing text in selected font)
- [x] Save as text + font family

## Files Changed
| File | Change |
|------|--------|
| `src/components/signature/SignaturePad.tsx` | New (S-68) |
| `src/components/signature/TypedSignature.tsx` | New (S-69) |
| `src/components/signature/index.ts` | Barrel export |
| `src/components/signature/__tests__/SignaturePad.test.ts` | 5 tests |
| `src/components/signature/__tests__/TypedSignature.test.ts` | 6 tests |
| `package.json` | +react-native-svg |

## Test Plan
- [x] TypeScript compiles clean (0 errors)
- [x] All 11 tests pass
- [x] Prettier formatting verified
- [ ] Manual test: draw signature, clear, undo, save
- [ ] Manual test: type name, switch fonts, preview updates, save
- [ ] Manual test: dark mode rendering for both components

🤖 Generated with [Claude Code](https://claude.com/claude-code)