### PR TITLE
feat(server): add Claude API service with prompt engineering (S-49)

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -16,3 +16,10 @@ APPLE_CLIENT_ID=
 
 # Dev tokens — accepts "dev:<userId>" for local testing (default: true in dev, false in prod)
 AUTH_DEV_TOKENS=true
+
+# Anthropic / Claude API (get from console.anthropic.com → API Keys)
+ANTHROPIC_API_KEY=
+# Optional: override model (default: claude-sonnet-4-20250514)
+# CLAUDE_MODEL=claude-sonnet-4-20250514
+# Optional: override max tokens (default: 4096)
+# CLAUDE_MAX_TOKENS=4096

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "@fillit/shared": "workspace:*",
     "@hono/node-server": "^1.13.0",
     "apple-signin-auth": "^2.0.0",

--- a/apps/server/src/__tests__/auth.test.ts
+++ b/apps/server/src/__tests__/auth.test.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import type { AppEnv } from '../types.js';
 import { createAuthMiddleware } from '../middleware/auth.js';
 import { DevTokenVerifier } from '../auth/dev-verifier.js';
-import type { TokenVerifier, VerifyResult } from '../auth/types.js';
+import type { TokenVerifier } from '../auth/types.js';
 
 // ─── DevTokenVerifier ──────────────────────────────────────────────
 

--- a/apps/server/src/__tests__/claude.test.ts
+++ b/apps/server/src/__tests__/claude.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClaudeService, type AnalyzeRequest } from '../services/claude.js';
+
+// ─── Mock Anthropic SDK ────────────────────────────────────────────
+
+const mockCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: mockCreate };
+    constructor() {}
+  },
+}));
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function makeRequest(overrides?: Partial<AnalyzeRequest>): AnalyzeRequest {
+  return {
+    pages: [
+      {
+        pageNumber: 1,
+        imageBase64: 'dGVzdA==', // "test" in base64
+        ocrBlocks: [
+          {
+            text: 'First Name',
+            bounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.05 },
+            confidence: 0.95,
+          },
+        ],
+      },
+    ],
+    availableFields: ['firstName', 'lastName', 'email', 'saIdNumber'],
+    ...overrides,
+  };
+}
+
+function makeToolResponse(fields: unknown[], extras?: Record<string, unknown>) {
+  return {
+    content: [
+      {
+        type: 'tool_use',
+        id: 'tool-1',
+        name: 'report_detected_fields',
+        input: { fields, ...extras },
+      },
+    ],
+    usage: { input_tokens: 500, output_tokens: 200 },
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe('ClaudeService', () => {
+  let service: ClaudeService;
+
+  beforeEach(() => {
+    mockCreate.mockReset();
+    service = new ClaudeService({ apiKey: 'test-key' });
+  });
+
+  describe('analyzeDocument', () => {
+    it('should call Anthropic API with correct structure', async () => {
+      mockCreate.mockResolvedValue(
+        makeToolResponse([
+          {
+            id: 'field-1',
+            pageNumber: 1,
+            label: 'First Name',
+            fieldType: 'text',
+            bounds: { x: 0.1, y: 0.25, width: 0.3, height: 0.04 },
+            matchedField: 'firstName',
+            matchConfidence: 0.92,
+          },
+        ]),
+      );
+
+      await service.analyzeDocument(makeRequest());
+
+      expect(mockCreate).toHaveBeenCalledOnce();
+      const callArgs = mockCreate.mock.calls[0]![0];
+      expect(callArgs.system).toContain('document field detection');
+      expect(callArgs.tools).toHaveLength(1);
+      expect(callArgs.tools[0].name).toBe('report_detected_fields');
+      expect(callArgs.tool_choice).toEqual({
+        type: 'tool',
+        name: 'report_detected_fields',
+      });
+    });
+
+    it('should return parsed fields from tool_use response', async () => {
+      const fields = [
+        {
+          id: 'field-1',
+          pageNumber: 1,
+          label: 'First Name',
+          fieldType: 'text',
+          bounds: { x: 0.1, y: 0.25, width: 0.3, height: 0.04 },
+          matchedField: 'firstName',
+          matchConfidence: 0.92,
+        },
+        {
+          id: 'field-2',
+          pageNumber: 1,
+          label: 'Signature',
+          fieldType: 'signature',
+          bounds: { x: 0.1, y: 0.8, width: 0.5, height: 0.1 },
+          matchedField: null,
+          matchConfidence: 0,
+        },
+      ];
+
+      mockCreate.mockResolvedValue(
+        makeToolResponse(fields, {
+          documentType: 'employment form',
+          documentLanguage: 'English',
+        }),
+      );
+
+      const result = await service.analyzeDocument(makeRequest());
+
+      expect(result.fields).toHaveLength(2);
+      expect(result.fields[0]!.label).toBe('First Name');
+      expect(result.fields[0]!.matchedField).toBe('firstName');
+      expect(result.fields[0]!.matchConfidence).toBe(0.92);
+      expect(result.fields[1]!.fieldType).toBe('signature');
+      expect(result.fields[1]!.matchedField).toBeNull();
+      expect(result.documentType).toBe('employment form');
+      expect(result.documentLanguage).toBe('English');
+    });
+
+    it('should include image blocks for each page', async () => {
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+
+      await service.analyzeDocument(
+        makeRequest({
+          pages: [
+            { pageNumber: 1, imageBase64: 'aW1hZ2Ux', ocrBlocks: [] },
+            { pageNumber: 2, imageBase64: 'aW1hZ2Uy', ocrBlocks: [] },
+          ],
+        }),
+      );
+
+      const content = mockCreate.mock.calls[0]![0].messages[0].content;
+      const imageBlocks = content.filter((b: { type: string }) => b.type === 'image');
+      expect(imageBlocks).toHaveLength(2);
+      expect(imageBlocks[0].source.data).toBe('aW1hZ2Ux');
+      expect(imageBlocks[1].source.data).toBe('aW1hZ2Uy');
+    });
+
+    it('should include OCR blocks as text context', async () => {
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+
+      await service.analyzeDocument(makeRequest());
+
+      const content = mockCreate.mock.calls[0]![0].messages[0].content;
+      const textBlocks = content.filter((b: { type: string }) => b.type === 'text');
+      const ocrBlock = textBlocks.find((b: { text: string }) => b.text.includes('First Name'));
+      expect(ocrBlock).toBeDefined();
+      expect(ocrBlock.text).toContain('conf=0.95');
+    });
+
+    it('should include available fields in the prompt', async () => {
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+
+      await service.analyzeDocument(makeRequest());
+
+      const content = mockCreate.mock.calls[0]![0].messages[0].content;
+      const fieldsBlock = content.find(
+        (b: { type: string; text?: string }) =>
+          b.type === 'text' && b.text?.includes('Available profile fields'),
+      );
+      expect(fieldsBlock).toBeDefined();
+      expect(fieldsBlock.text).toContain('firstName');
+      expect(fieldsBlock.text).toContain('saIdNumber');
+    });
+
+    it('should throw when Claude returns no tool_use block', async () => {
+      mockCreate.mockResolvedValue({
+        content: [{ type: 'text', text: 'I cannot process this.' }],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+
+      await expect(service.analyzeDocument(makeRequest())).rejects.toThrow(
+        'Claude did not return a tool_use response',
+      );
+    });
+
+    it('should handle empty fields array', async () => {
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+
+      const result = await service.analyzeDocument(makeRequest());
+      expect(result.fields).toEqual([]);
+    });
+
+    it('should propagate API errors', async () => {
+      mockCreate.mockRejectedValue(new Error('Rate limited'));
+
+      await expect(service.analyzeDocument(makeRequest())).rejects.toThrow('Rate limited');
+    });
+  });
+
+  describe('usage tracking', () => {
+    it('should track token usage across requests', async () => {
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+
+      await service.analyzeDocument(makeRequest());
+      await service.analyzeDocument(makeRequest());
+
+      const usage = service.getUsage();
+      expect(usage.inputTokens).toBe(1000); // 500 * 2
+      expect(usage.outputTokens).toBe(400); // 200 * 2
+      expect(usage.requests).toBe(2);
+    });
+
+    it('should reset usage counters', async () => {
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+
+      await service.analyzeDocument(makeRequest());
+      service.resetUsage();
+
+      const usage = service.getUsage();
+      expect(usage.inputTokens).toBe(0);
+      expect(usage.outputTokens).toBe(0);
+      expect(usage.requests).toBe(0);
+    });
+  });
+
+  describe('configuration', () => {
+    it('should use default model when not specified', async () => {
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+      await service.analyzeDocument(makeRequest());
+
+      expect(mockCreate.mock.calls[0]![0].model).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('should use custom model when specified', async () => {
+      const customService = new ClaudeService({
+        apiKey: 'test-key',
+        model: 'claude-haiku-4-5-20251001',
+      });
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+      await customService.analyzeDocument(makeRequest());
+
+      expect(mockCreate.mock.calls[0]![0].model).toBe('claude-haiku-4-5-20251001');
+    });
+
+    it('should use custom max tokens when specified', async () => {
+      const customService = new ClaudeService({
+        apiKey: 'test-key',
+        maxTokens: 8192,
+      });
+      mockCreate.mockResolvedValue(makeToolResponse([]));
+      await customService.analyzeDocument(makeRequest());
+
+      expect(mockCreate.mock.calls[0]![0].max_tokens).toBe(8192);
+    });
+  });
+});
+
+// ─── Factory ───────────────────────────────────────────────────────
+
+describe('getClaudeService', () => {
+  it('should throw when ANTHROPIC_API_KEY is not set', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const { getClaudeService, resetClaudeService } = await import('../services/claude.js');
+    resetClaudeService();
+
+    expect(() => getClaudeService()).toThrow('ANTHROPIC_API_KEY');
+  });
+
+  it('should return a ClaudeService instance when API key is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'test-api-key';
+    const { getClaudeService, resetClaudeService } = await import('../services/claude.js');
+    resetClaudeService();
+
+    const service = getClaudeService();
+    expect(service).toBeInstanceOf(ClaudeService);
+  });
+});

--- a/apps/server/src/services/claude.ts
+++ b/apps/server/src/services/claude.ts
@@ -1,0 +1,301 @@
+/**
+ * Claude API service for document field detection.
+ *
+ * Uses the Anthropic SDK with vision + tool_use to analyze scanned
+ * document images, detect fillable fields, and map them to profile
+ * field paths. Structured output is enforced via a tool definition.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type { DetectedFieldType } from '@fillit/shared';
+
+// ─── Request / Response Types ──────────────────────────────────────
+
+/** An OCR text block with its bounding box on the page. */
+export interface OcrBlock {
+  text: string;
+  bounds: { x: number; y: number; width: number; height: number };
+  confidence: number;
+}
+
+/** A single page sent for analysis. */
+export interface AnalyzePage {
+  pageNumber: number;
+  /** Base64-encoded JPEG image data (no data URI prefix). */
+  imageBase64: string;
+  ocrBlocks: OcrBlock[];
+}
+
+/** Request payload for document analysis. */
+export interface AnalyzeRequest {
+  pages: AnalyzePage[];
+  /** Profile field names available for matching. */
+  availableFields: string[];
+}
+
+/** A detected field returned by Claude. */
+export interface AnalyzedField {
+  id: string;
+  pageNumber: number;
+  label: string;
+  fieldType: DetectedFieldType;
+  bounds: { x: number; y: number; width: number; height: number };
+  matchedField: string | null;
+  matchConfidence: number;
+  notes?: string;
+}
+
+/** Response from Claude's field detection. */
+export interface AnalyzeResponse {
+  fields: AnalyzedField[];
+  documentType?: string;
+  documentLanguage?: string;
+}
+
+// ─── System Prompt ─────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are a document field detection and matching assistant. You analyze scanned documents to identify fillable form fields and map them to a user's profile data structure.
+
+Your task:
+1. Examine each page image and the OCR text with bounding boxes
+2. Identify all fillable fields (text inputs, date fields, checkboxes, signature lines, initial lines)
+3. For each field, determine what information it expects
+4. Map each field to the most appropriate profile field path from the provided schema
+
+Rules:
+- A "fillable field" is any blank space, line, box, or area where a person would write/enter information
+- Use the OCR text and visual layout together — labels are usually adjacent to their fields
+- Distinguish between pre-printed text (not fillable) and blank areas (fillable)
+- For checkboxes, identify what each option represents
+- For signature/initial fields, mark them as type "signature" or "initial"
+- Return confidence scores (0.0-1.0) for each mapping
+- If a field doesn't match any profile field, set matchedField to null
+- Be aware of South African document conventions (SA ID numbers, provinces, etc.)
+- Generate a unique id for each field (e.g. "field-1", "field-2")`;
+
+// ─── Tool Definition ───────────────────────────────────────────────
+
+const DETECT_FIELDS_TOOL: Anthropic.Tool = {
+  name: 'report_detected_fields',
+  description:
+    'Report all detected fillable fields and their profile mappings for the analyzed document.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      fields: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', description: 'Unique field identifier' },
+            pageNumber: { type: 'number', description: 'Page number (1-based)' },
+            label: { type: 'string', description: 'Field label text' },
+            fieldType: {
+              type: 'string',
+              enum: ['text', 'date', 'checkbox', 'signature', 'initial', 'number'],
+              description: 'Type of field',
+            },
+            bounds: {
+              type: 'object',
+              properties: {
+                x: { type: 'number' },
+                y: { type: 'number' },
+                width: { type: 'number' },
+                height: { type: 'number' },
+              },
+              required: ['x', 'y', 'width', 'height'],
+            },
+            matchedField: {
+              type: ['string', 'null'],
+              description: 'Profile field path or null if no match',
+            },
+            matchConfidence: {
+              type: 'number',
+              description: 'Confidence score 0.0-1.0',
+            },
+            notes: {
+              type: 'string',
+              description: 'Optional reasoning notes',
+            },
+          },
+          required: [
+            'id',
+            'pageNumber',
+            'label',
+            'fieldType',
+            'bounds',
+            'matchedField',
+            'matchConfidence',
+          ],
+        },
+      },
+      documentType: {
+        type: 'string',
+        description: 'Detected document type (e.g. "medical form", "tax return")',
+      },
+      documentLanguage: {
+        type: 'string',
+        description: 'Document language (e.g. "English", "Afrikaans", "bilingual")',
+      },
+    },
+    required: ['fields'],
+  },
+};
+
+// ─── Service ───────────────────────────────────────────────────────
+
+export interface ClaudeServiceConfig {
+  apiKey: string;
+  /** Model to use. @default "claude-sonnet-4-20250514" */
+  model?: string;
+  /** Max tokens for the response. @default 4096 */
+  maxTokens?: number;
+  /** Max retry attempts on transient errors. @default 2 */
+  maxRetries?: number;
+}
+
+export class ClaudeService {
+  private client: Anthropic;
+  private model: string;
+  private maxTokens: number;
+
+  /** Running token usage counters. */
+  private usage = { inputTokens: 0, outputTokens: 0, requests: 0 };
+
+  constructor(config: ClaudeServiceConfig) {
+    this.client = new Anthropic({
+      apiKey: config.apiKey,
+      maxRetries: config.maxRetries ?? 2,
+    });
+    this.model = config.model ?? 'claude-sonnet-4-20250514';
+    this.maxTokens = config.maxTokens ?? 4096;
+  }
+
+  /**
+   * Analyze document pages and detect fillable fields.
+   *
+   * Sends page images + OCR data to Claude with the field detection
+   * tool, enforcing structured JSON output. Returns parsed fields
+   * mapped to profile field paths.
+   */
+  async analyzeDocument(request: AnalyzeRequest): Promise<AnalyzeResponse> {
+    const userContent = this.buildUserMessage(request);
+
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: this.maxTokens,
+      system: SYSTEM_PROMPT,
+      tools: [DETECT_FIELDS_TOOL],
+      tool_choice: { type: 'tool', name: 'report_detected_fields' },
+      messages: [{ role: 'user', content: userContent }],
+    });
+
+    // Track usage
+    this.usage.inputTokens += response.usage.input_tokens;
+    this.usage.outputTokens += response.usage.output_tokens;
+    this.usage.requests += 1;
+
+    return this.parseResponse(response);
+  }
+
+  /** Get cumulative token usage stats. */
+  getUsage(): { inputTokens: number; outputTokens: number; requests: number } {
+    return { ...this.usage };
+  }
+
+  /** Reset usage counters. */
+  resetUsage(): void {
+    this.usage = { inputTokens: 0, outputTokens: 0, requests: 0 };
+  }
+
+  // ─── Private ───────────────────────────────────────────────────
+
+  private buildUserMessage(
+    request: AnalyzeRequest,
+  ): Array<Anthropic.ImageBlockParam | Anthropic.TextBlockParam> {
+    const content: Array<Anthropic.ImageBlockParam | Anthropic.TextBlockParam> = [];
+
+    // Add available fields context
+    content.push({
+      type: 'text',
+      text: `Available profile fields for matching:\n${request.availableFields.join('\n')}\n\nAnalyze the following document pages:`,
+    });
+
+    // Add each page's image and OCR data
+    for (const page of request.pages) {
+      content.push({
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/jpeg',
+          data: page.imageBase64,
+        },
+      });
+
+      if (page.ocrBlocks.length > 0) {
+        const ocrText = page.ocrBlocks
+          .map(
+            (b) =>
+              `"${b.text}" at (${b.bounds.x.toFixed(3)}, ${b.bounds.y.toFixed(3)}, ${b.bounds.width.toFixed(3)}, ${b.bounds.height.toFixed(3)}) conf=${b.confidence.toFixed(2)}`,
+          )
+          .join('\n');
+
+        content.push({
+          type: 'text',
+          text: `Page ${page.pageNumber} OCR blocks (normalized 0-1 coordinates):\n${ocrText}`,
+        });
+      }
+    }
+
+    return content;
+  }
+
+  private parseResponse(response: Anthropic.Message): AnalyzeResponse {
+    const toolBlock = response.content.find(
+      (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
+    );
+
+    if (!toolBlock) {
+      throw new Error('Claude did not return a tool_use response');
+    }
+
+    const input = toolBlock.input as Record<string, unknown>;
+    const fields = (input.fields ?? []) as AnalyzedField[];
+
+    return {
+      fields,
+      documentType: (input.documentType as string) ?? undefined,
+      documentLanguage: (input.documentLanguage as string) ?? undefined,
+    };
+  }
+}
+
+// ─── Factory ───────────────────────────────────────────────────────
+
+let instance: ClaudeService | null = null;
+
+/**
+ * Get or create the singleton ClaudeService instance.
+ * Reads ANTHROPIC_API_KEY from environment.
+ */
+export function getClaudeService(): ClaudeService {
+  if (!instance) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error('ANTHROPIC_API_KEY environment variable is required');
+    }
+    instance = new ClaudeService({
+      apiKey,
+      model: process.env.CLAUDE_MODEL ?? undefined,
+      maxTokens: process.env.CLAUDE_MAX_TOKENS
+        ? parseInt(process.env.CLAUDE_MAX_TOKENS, 10)
+        : undefined,
+    });
+  }
+  return instance;
+}
+
+/** Reset the singleton (for testing). */
+export function resetClaudeService(): void {
+  instance = null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.80.0
+        version: 0.80.0(zod@3.25.76)
       '@fillit/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -210,6 +213,15 @@ importers:
         version: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
+
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -3000,6 +3012,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -3967,6 +3983,9 @@ packages:
   toqr@0.1.1:
     resolution: {integrity: sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -4304,6 +4323,12 @@ packages:
         optional: true
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.80.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5979,7 +6004,9 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.83.2': {}
 
@@ -7633,6 +7660,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -8675,6 +8707,8 @@ snapshots:
   toidentifier@1.0.1: {}
 
   toqr@0.1.1: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
- **ClaudeService** — integrates `@anthropic-ai/sdk` for document field detection
- Vision + tool_use: sends page images + OCR bounding boxes, receives structured field data
- System prompt tuned for South African documents (bilingual EN/AF, SA ID numbers, provinces)
- Structured output enforced via `report_detected_fields` tool definition
- Token usage tracking (input/output tokens, request count)
- Configurable model, max tokens, retries via env vars
- Singleton factory pattern with `getClaudeService()`

Closes #50

## How It Works
```
Mobile app → POST /api/analyze (S-50, future)
  → ClaudeService.analyzeDocument({pages, availableFields})
    → Anthropic API (vision + tool_use)
    → Parsed AnalyzeResponse { fields[], documentType, documentLanguage }
```

## Env Vars (added to .env.example)
| Variable | Required | Default |
|----------|----------|---------|
| ANTHROPIC_API_KEY | Yes | - |
| CLAUDE_MODEL | No | claude-sonnet-4-20250514 |
| CLAUDE_MAX_TOKENS | No | 4096 |

## Acceptance Criteria
- [x] @anthropic-ai/sdk integration
- [x] Prompt template for field detection (SA-aware, bilingual)
- [x] Structured JSON output parsing (via tool_use)
- [x] Error handling and retries (SDK maxRetries + error propagation)
- [x] Token usage tracking (per-request and cumulative)

## Test Plan
- [x] 15 new tests (API calls, response parsing, usage tracking, config, factory)
- [x] 56 total server tests passing (no regressions)
- [x] TypeScript clean, Prettier formatted
- [ ] Manual: set ANTHROPIC_API_KEY, call analyzeDocument with test image

🤖 Generated with [Claude Code](https://claude.com/claude-code)