### PR TITLE
feat(server): add per-user rate limiting middleware (S-48)

### DIFF
--- a/apps/server/src/__tests__/rate-limit.test.ts
+++ b/apps/server/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import type { AppEnv } from '../types.js';
+import { RateLimiter, RATE_LIMIT_TIERS } from '../services/rate-limiter.js';
+import { createRateLimitMiddleware } from '../middleware/rate-limit.js';
+
+// ─── RateLimiter service ───────────────────────────────────────────
+
+describe('RateLimiter', () => {
+  let limiter: RateLimiter;
+
+  beforeEach(() => {
+    limiter = new RateLimiter({ maxRequests: 3, windowMs: 1000 });
+  });
+
+  it('should allow requests within the limit', () => {
+    const r1 = limiter.check('user-1');
+    expect(r1.allowed).toBe(true);
+    expect(r1.remaining).toBe(2);
+    expect(r1.limit).toBe(3);
+
+    const r2 = limiter.check('user-1');
+    expect(r2.allowed).toBe(true);
+    expect(r2.remaining).toBe(1);
+
+    const r3 = limiter.check('user-1');
+    expect(r3.allowed).toBe(true);
+    expect(r3.remaining).toBe(0);
+  });
+
+  it('should reject requests over the limit', () => {
+    limiter.check('user-1');
+    limiter.check('user-1');
+    limiter.check('user-1');
+
+    const r4 = limiter.check('user-1');
+    expect(r4.allowed).toBe(false);
+    expect(r4.remaining).toBe(0);
+  });
+
+  it('should track users independently', () => {
+    limiter.check('user-1');
+    limiter.check('user-1');
+    limiter.check('user-1');
+
+    const result = limiter.check('user-2');
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(2);
+  });
+
+  it('should reset after the window expires', async () => {
+    const shortLimiter = new RateLimiter({ maxRequests: 1, windowMs: 50 });
+    shortLimiter.check('user-1');
+
+    const blocked = shortLimiter.check('user-1');
+    expect(blocked.allowed).toBe(false);
+
+    // Wait for window to expire
+    await new Promise((r) => setTimeout(r, 60));
+
+    const allowed = shortLimiter.check('user-1');
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it('should support custom tiers', () => {
+    const premiumTier = { maxRequests: 100, windowMs: 60_000 };
+    const result = limiter.check('user-1', premiumTier);
+    expect(result.limit).toBe(100);
+    expect(result.remaining).toBe(99);
+  });
+
+  it('should provide a resetAt timestamp', () => {
+    const result = limiter.check('user-1');
+    expect(result.resetAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('should clear all records', () => {
+    limiter.check('user-1');
+    limiter.check('user-2');
+    expect(limiter.size).toBe(2);
+
+    limiter.clear();
+    expect(limiter.size).toBe(0);
+  });
+});
+
+describe('RATE_LIMIT_TIERS', () => {
+  it('should define free and premium tiers', () => {
+    expect(RATE_LIMIT_TIERS.free).toBeDefined();
+    expect(RATE_LIMIT_TIERS.free!.maxRequests).toBe(10);
+    expect(RATE_LIMIT_TIERS.premium).toBeDefined();
+    expect(RATE_LIMIT_TIERS.premium!.maxRequests).toBe(60);
+  });
+});
+
+// ─── Rate limit middleware ─────────────────────────────────────────
+
+describe('createRateLimitMiddleware', () => {
+  function createApp(limiter: RateLimiter) {
+    const app = new Hono<AppEnv>();
+    // Simulate auth setting userId
+    app.use('*', async (c, next) => {
+      c.set('userId', 'test-user');
+      c.set('authProvider', 'dev');
+      await next();
+    });
+    app.use('*', createRateLimitMiddleware(limiter));
+    app.get('/test', (c) => c.json({ ok: true }));
+    app.onError((err, c) => {
+      const status = 'statusCode' in err ? (err as any).statusCode : 500;
+      return c.json({ error: err.message }, status);
+    });
+    return app;
+  }
+
+  it('should set rate limit headers on allowed requests', async () => {
+    const limiter = new RateLimiter({ maxRequests: 5, windowMs: 60_000 });
+    const app = createApp(limiter);
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('5');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('4');
+    expect(res.headers.get('X-RateLimit-Reset')).toBeTruthy();
+  });
+
+  it('should return 429 when limit is exceeded', async () => {
+    const limiter = new RateLimiter({ maxRequests: 2, windowMs: 60_000 });
+    const app = createApp(limiter);
+
+    await app.request('/test');
+    await app.request('/test');
+    const res = await app.request('/test');
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('Rate limit exceeded');
+  });
+
+  it('should set headers even on 429 responses', async () => {
+    const limiter = new RateLimiter({ maxRequests: 1, windowMs: 60_000 });
+    const app = createApp(limiter);
+
+    await app.request('/test');
+    const res = await app.request('/test');
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('1');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('0');
+  });
+
+  it('should decrement remaining with each request', async () => {
+    const limiter = new RateLimiter({ maxRequests: 3, windowMs: 60_000 });
+    const app = createApp(limiter);
+
+    const r1 = await app.request('/test');
+    expect(r1.headers.get('X-RateLimit-Remaining')).toBe('2');
+
+    const r2 = await app.request('/test');
+    expect(r2.headers.get('X-RateLimit-Remaining')).toBe('1');
+
+    const r3 = await app.request('/test');
+    expect(r3.headers.get('X-RateLimit-Remaining')).toBe('0');
+  });
+});
+
+// ─── App integration ───────────────────────────────────────────────
+
+describe('app rate limit integration', () => {
+  it('should not rate limit public routes', async () => {
+    process.env.AUTH_DEV_TOKENS = 'true';
+    const app = (await import('../app.js')).default;
+
+    // Public routes should never be rate limited
+    for (let i = 0; i < 15; i++) {
+      const res = await app.request('/health');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('should include rate limit headers on /api/* routes', async () => {
+    process.env.AUTH_DEV_TOKENS = 'true';
+    const app = (await import('../app.js')).default;
+
+    const res = await app.request('/api/auth/me', {
+      headers: { Authorization: 'Bearer dev:rate-test-user' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-RateLimit-Limit')).toBeTruthy();
+    expect(res.headers.get('X-RateLimit-Remaining')).toBeTruthy();
+  });
+});

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,8 +1,16 @@
 import { Hono } from 'hono';
 import { APP_NAME } from '@fillit/shared';
 import type { AppEnv } from './types.js';
-import { requestId, cors, logger, errorHandler, createAuthMiddleware } from './middleware/index.js';
+import {
+  requestId,
+  cors,
+  logger,
+  errorHandler,
+  createAuthMiddleware,
+  createRateLimitMiddleware,
+} from './middleware/index.js';
 import { createVerifiers } from './auth/index.js';
+import { RateLimiter, RATE_LIMIT_TIERS } from './services/rate-limiter.js';
 
 const app = new Hono<AppEnv>();
 
@@ -18,6 +26,10 @@ app.onError(errorHandler);
 const verifiers = createVerifiers();
 const auth = createAuthMiddleware(verifiers);
 app.use('/api/*', auth);
+
+// Rate limiting — applied after auth so userId is available
+const rateLimiter = new RateLimiter(RATE_LIMIT_TIERS.free);
+app.use('/api/*', createRateLimitMiddleware(rateLimiter));
 
 // Public routes
 const startTime = Date.now();

--- a/apps/server/src/middleware/index.ts
+++ b/apps/server/src/middleware/index.ts
@@ -3,3 +3,4 @@ export { logger } from './logger.js';
 export { cors } from './cors.js';
 export { errorHandler } from './error-handler.js';
 export { createAuthMiddleware } from './auth.js';
+export { createRateLimitMiddleware } from './rate-limit.js';

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -1,0 +1,37 @@
+/**
+ * Per-user rate limiting middleware.
+ *
+ * Uses the userId from the auth context to track request counts.
+ * Sets standard rate limit headers on every response and returns
+ * 429 when the limit is exceeded.
+ */
+
+import { createMiddleware } from 'hono/factory';
+import type { AppEnv } from '../types.js';
+import { RateLimiter, type RateLimitTier } from '../services/rate-limiter.js';
+import { TooManyRequestsError } from '../utils/errors.js';
+
+/**
+ * Create a rate limiting middleware with the given limiter and optional tier.
+ *
+ * Must be applied after the auth middleware so that `c.get('userId')` is available.
+ */
+export function createRateLimitMiddleware(limiter: RateLimiter, tier?: RateLimitTier) {
+  return createMiddleware<AppEnv>(async (c, next) => {
+    const userId = c.get('userId');
+    const key = userId || c.req.header('X-Forwarded-For') || 'anonymous';
+
+    const result = limiter.check(key, tier);
+
+    // Always set rate limit headers
+    c.header('X-RateLimit-Limit', String(result.limit));
+    c.header('X-RateLimit-Remaining', String(result.remaining));
+    c.header('X-RateLimit-Reset', String(result.resetAt));
+
+    if (!result.allowed) {
+      throw new TooManyRequestsError('Rate limit exceeded. Please try again later.');
+    }
+
+    await next();
+  });
+}

--- a/apps/server/src/services/rate-limiter.ts
+++ b/apps/server/src/services/rate-limiter.ts
@@ -1,0 +1,99 @@
+/**
+ * In-memory sliding window rate limiter.
+ *
+ * Tracks request counts per key (typically userId) within a
+ * configurable time window. Supports multiple tiers with
+ * different limits.
+ */
+
+/** Rate limit configuration for a single tier. */
+export interface RateLimitTier {
+  /** Maximum requests allowed in the window. */
+  maxRequests: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+}
+
+/** Predefined tier configurations. */
+export const RATE_LIMIT_TIERS: Record<string, RateLimitTier> = {
+  free: { maxRequests: 10, windowMs: 60_000 },
+  premium: { maxRequests: 60, windowMs: 60_000 },
+};
+
+/** Result of a rate limit check. */
+export interface RateLimitResult {
+  /** Whether the request is allowed. */
+  allowed: boolean;
+  /** Maximum requests in the window. */
+  limit: number;
+  /** Remaining requests in the current window. */
+  remaining: number;
+  /** Unix timestamp (seconds) when the window resets. */
+  resetAt: number;
+}
+
+/** Internal record of request timestamps for a single key. */
+interface RequestRecord {
+  timestamps: number[];
+}
+
+export class RateLimiter {
+  private records = new Map<string, RequestRecord>();
+  private defaultTier: RateLimitTier;
+
+  constructor(defaultTier: RateLimitTier = RATE_LIMIT_TIERS.free!) {
+    this.defaultTier = defaultTier;
+  }
+
+  /**
+   * Check and consume a rate limit token for the given key.
+   *
+   * Prunes expired timestamps, then checks if the request is within
+   * the limit. If allowed, records the new timestamp.
+   */
+  check(key: string, tier?: RateLimitTier): RateLimitResult {
+    const { maxRequests, windowMs } = tier ?? this.defaultTier;
+    const now = Date.now();
+    const windowStart = now - windowMs;
+
+    let record = this.records.get(key);
+    if (!record) {
+      record = { timestamps: [] };
+      this.records.set(key, record);
+    }
+
+    // Prune expired timestamps
+    record.timestamps = record.timestamps.filter((t) => t > windowStart);
+
+    const resetAt = Math.ceil((now + windowMs) / 1000);
+
+    if (record.timestamps.length >= maxRequests) {
+      return {
+        allowed: false,
+        limit: maxRequests,
+        remaining: 0,
+        resetAt,
+      };
+    }
+
+    // Consume a token
+    record.timestamps.push(now);
+
+    return {
+      allowed: true,
+      limit: maxRequests,
+      remaining: maxRequests - record.timestamps.length,
+      resetAt,
+    };
+  }
+
+  /** Clear all records (for testing). */
+  clear(): void {
+    this.records.clear();
+  }
+
+  /** Get the number of tracked keys (for monitoring). */
+  get size(): number {
+    return this.records.size;
+  }
+}

--- a/apps/server/src/utils/errors.ts
+++ b/apps/server/src/utils/errors.ts
@@ -36,3 +36,10 @@ export class ForbiddenError extends AppError {
     this.name = 'ForbiddenError';
   }
 }
+
+export class TooManyRequestsError extends AppError {
+  constructor(message = 'Too many requests') {
+    super(429, 'TOO_MANY_REQUESTS', message);
+    this.name = 'TooManyRequestsError';
+  }
+}


### PR DESCRIPTION
## Summary
- **RateLimiter** service — in-memory sliding window counter per userId
- **Rate limit middleware** — applied to `/api/*` routes after auth
- Standard headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
- 429 Too Many Requests when limit exceeded
- Configurable tiers: free (10 req/min), premium (60 req/min)
- `TooManyRequestsError` added to error hierarchy

Closes #49

## Acceptance Criteria
- [x] Per-user rate limiting (10 requests/minute free tier)
- [x] Rate limit headers in response
- [x] 429 Too Many Requests response
- [x] Configurable limits per tier (free/premium)

## Test Plan
- [x] 14 new tests (limiter service, middleware, app integration)
- [x] 70 total server tests passing (no regressions)
- [x] TypeScript clean, Prettier formatted
- [ ] Manual: send 11 rapid requests with dev token, verify 429 on 11th

🤖 Generated with [Claude Code](https://claude.com/claude-code)