### PR TITLE
fix: address critical and high findings from retroactive code review

### DIFF
--- a/apps/mobile/src/components/document/FieldEditorSheet.tsx
+++ b/apps/mobile/src/components/document/FieldEditorSheet.tsx
@@ -118,7 +118,7 @@ export function FieldEditorSheet({
     Keyboard.dismiss();
     onSave({
       fieldId: field.id,
-      value: source === 'skip' ? '' : editValue,
+      value: source === 'skip' ? '' : editValue.trim(),
       source,
       isConfirmed: source !== 'skip',
     });
@@ -162,7 +162,12 @@ export function FieldEditorSheet({
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="box-none" testID="field-editor-sheet">
       {/* Backdrop */}
-      <Pressable style={StyleSheet.absoluteFill} onPress={handleBackdropPress}>
+      <Pressable
+        style={StyleSheet.absoluteFill}
+        onPress={handleBackdropPress}
+        accessibilityRole="button"
+        accessibilityLabel="Close field editor"
+      >
         <Animated.View
           style={[StyleSheet.absoluteFill, { backgroundColor: '#000' }, backdropStyle]}
           testID="field-editor-backdrop"
@@ -183,6 +188,8 @@ export function FieldEditorSheet({
           sheetStyle,
         ]}
         testID="field-editor-content"
+        accessibilityViewIsModal={true}
+        accessibilityRole="none"
       >
         {/* Handle */}
         <View style={styles.handleContainer}>
@@ -266,6 +273,7 @@ export function FieldEditorSheet({
               variant="outlined"
               disabled={source !== 'manual'}
               placeholder={source === 'profile' ? 'From profile' : 'Enter value'}
+              maxLength={500}
               testID="field-editor-value-input"
               containerStyle={{ marginBottom: 0 }}
             />

--- a/apps/mobile/src/components/signature/SignaturePad.tsx
+++ b/apps/mobile/src/components/signature/SignaturePad.tsx
@@ -6,8 +6,8 @@
  * as SVG path data strings for compact, resolution-independent storage.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 import Svg, { Path } from 'react-native-svg';
 
@@ -65,6 +65,12 @@ function buildPathData(points: Array<{ x: number; y: number }>): string {
   return d;
 }
 
+const COLOR_NAMES: Record<string, string> = {
+  '#000000': 'Black',
+  '#1A237E': 'Dark Blue',
+  '#1B5E20': 'Dark Green',
+};
+
 // ─── Component ─────────────────────────────────────────────────────
 
 const DEFAULT_WIDTHS = [1.5, 2.5, 4];
@@ -87,7 +93,18 @@ export function SignaturePad({
   const [activeWidth, setActiveWidth] = useState(strokeWidth);
   const currentPoints = useRef<Array<{ x: number; y: number }>>([]);
 
+  // Refs for gesture callbacks to avoid stale closures
+  const activeColorRef = useRef(activeColor);
+  const activeWidthRef = useRef(activeWidth);
+  useEffect(() => {
+    activeColorRef.current = activeColor;
+  }, [activeColor]);
+  useEffect(() => {
+    activeWidthRef.current = activeWidth;
+  }, [activeWidth]);
+
   const isEmpty = strokes.length === 0;
+  const MAX_STROKES = 200;
 
   const handleClear = useCallback(() => {
     setStrokes([]);
@@ -116,11 +133,17 @@ export function SignaturePad({
         .onEnd(() => {
           const path = buildPathData(currentPoints.current);
           if (path) {
-            setStrokes((prev) => [...prev, { path, color: activeColor, width: activeWidth }]);
+            setStrokes((prev) => {
+              if (prev.length >= MAX_STROKES) return prev;
+              return [
+                ...prev,
+                { path, color: activeColorRef.current, width: activeWidthRef.current },
+              ];
+            });
           }
           currentPoints.current = [];
         }),
-    [activeColor, activeWidth],
+    [],
   );
 
   return (
@@ -162,7 +185,7 @@ export function SignaturePad({
         {/* Color picker */}
         <View style={styles.pickerRow}>
           {strokeColors.map((color) => (
-            <View
+            <Pressable
               key={color}
               style={[
                 styles.colorSwatch,
@@ -172,9 +195,9 @@ export function SignaturePad({
                   borderWidth: color === activeColor ? 2.5 : 0,
                 },
               ]}
-              onTouchEnd={() => setActiveColor(color)}
+              onPress={() => setActiveColor(color)}
               accessibilityRole="button"
-              accessibilityLabel={`Pen color ${color}`}
+              accessibilityLabel={`Pen color ${COLOR_NAMES[color] ?? color}`}
               accessibilityState={{ selected: color === activeColor }}
               testID={`signature-pad-color-${color}`}
             />
@@ -184,7 +207,7 @@ export function SignaturePad({
         {/* Width picker */}
         <View style={styles.pickerRow}>
           {strokeWidths.map((w) => (
-            <View
+            <Pressable
               key={w}
               style={[
                 styles.widthOption,
@@ -194,9 +217,9 @@ export function SignaturePad({
                   borderRadius: theme.radii.sm,
                 },
               ]}
-              onTouchEnd={() => setActiveWidth(w)}
+              onPress={() => setActiveWidth(w)}
               accessibilityRole="button"
-              accessibilityLabel={`Pen width ${w}`}
+              accessibilityLabel={`Pen width ${w === 1.5 ? 'thin' : w === 2.5 ? 'medium' : 'thick'}`}
               accessibilityState={{ selected: w === activeWidth }}
               testID={`signature-pad-width-${w}`}
             >
@@ -208,7 +231,7 @@ export function SignaturePad({
                   borderRadius: w / 2,
                 }}
               />
-            </View>
+            </Pressable>
           ))}
         </View>
       </View>

--- a/apps/mobile/src/components/signature/TypedSignature.tsx
+++ b/apps/mobile/src/components/signature/TypedSignature.tsx
@@ -88,6 +88,7 @@ export function TypedSignature({
         placeholder="Type your name"
         variant="outlined"
         autoCapitalize="words"
+        maxLength={100}
         testID="typed-signature-input"
       />
 

--- a/apps/server/src/__tests__/claude.test.ts
+++ b/apps/server/src/__tests__/claude.test.ts
@@ -167,7 +167,7 @@ describe('ClaudeService', () => {
       const content = mockCreate.mock.calls[0]![0].messages[0].content;
       const fieldsBlock = content.find(
         (b: { type: string; text?: string }) =>
-          b.type === 'text' && b.text?.includes('Available profile fields'),
+          b.type === 'text' && b.text?.includes('<available_fields>'),
       );
       expect(fieldsBlock).toBeDefined();
       expect(fieldsBlock.text).toContain('firstName');

--- a/apps/server/src/auth/apple-verifier.ts
+++ b/apps/server/src/auth/apple-verifier.ts
@@ -35,8 +35,14 @@ export class AppleTokenVerifier implements TokenVerifier {
           email: payload.email,
         },
       };
-    } catch {
-      // Token is not a valid Apple token — let the next verifier try
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const isValidationError =
+        message.includes('invalid') || message.includes('expired') || message.includes('audience');
+
+      if (!isValidationError) {
+        console.warn('[auth:apple] Verification error (possible infra issue):', message);
+      }
       return null;
     }
   }

--- a/apps/server/src/auth/dev-verifier.ts
+++ b/apps/server/src/auth/dev-verifier.ts
@@ -15,6 +15,7 @@
 import type { TokenVerifier, VerifyResult } from './types.js';
 
 const DEV_TOKEN_PREFIX = 'dev:';
+const USER_ID_PATTERN = /^[\w.@-]{1,128}$/;
 
 export class DevTokenVerifier implements TokenVerifier {
   readonly provider = 'dev' as const;
@@ -23,7 +24,7 @@ export class DevTokenVerifier implements TokenVerifier {
     if (!token.startsWith(DEV_TOKEN_PREFIX)) return null;
 
     const userId = token.slice(DEV_TOKEN_PREFIX.length).trim();
-    if (!userId) return null;
+    if (!userId || !USER_ID_PATTERN.test(userId)) return null;
 
     return {
       user: {

--- a/apps/server/src/auth/google-verifier.ts
+++ b/apps/server/src/auth/google-verifier.ts
@@ -35,8 +35,17 @@ export class GoogleTokenVerifier implements TokenVerifier {
           email: payload.email,
         },
       };
-    } catch {
-      // Token is not a valid Google token — let the next verifier try
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const isValidationError =
+        message.includes('Token used too late') ||
+        message.includes('Invalid token') ||
+        message.includes('Wrong recipient') ||
+        message.includes('Invalid value');
+
+      if (!isValidationError) {
+        console.warn('[auth:google] Verification error (possible infra issue):', message);
+      }
       return null;
     }
   }

--- a/apps/server/src/auth/registry.ts
+++ b/apps/server/src/auth/registry.ts
@@ -3,7 +3,7 @@
  *
  * Builds the chain of active verifiers based on environment configuration.
  * In production, only Google and Apple verifiers are registered (when their
- * credentials are present). In development, the dev verifier is also added.
+ * credentials are present). Dev tokens are NEVER available in production.
  */
 
 import type { TokenVerifier } from './types.js';
@@ -15,8 +15,8 @@ import { DevTokenVerifier } from './dev-verifier.js';
  * Create the list of active token verifiers from environment variables.
  *
  * Verifiers are registered when their credentials are available.
- * The dev verifier is included when AUTH_DEV_TOKENS is not explicitly "false".
- * In production (NODE_ENV=production), dev tokens are disabled by default.
+ * Dev tokens are enabled by default in non-production and hard-blocked
+ * in production regardless of env vars.
  */
 export function createVerifiers(): TokenVerifier[] {
   const verifiers: TokenVerifier[] = [];
@@ -34,12 +34,22 @@ export function createVerifiers(): TokenVerifier[] {
     verifiers.push(new AppleTokenVerifier({ clientId: appleClientId }));
   }
 
-  // Dev tokens — enabled by default in non-production, disabled in production
-  const devTokensSetting = process.env.AUTH_DEV_TOKENS;
-  const devTokensEnabled = devTokensSetting ? devTokensSetting === 'true' : !isProduction;
+  // Dev tokens — hard-blocked in production, enabled by default in dev
+  if (!isProduction) {
+    const devTokensSetting = process.env.AUTH_DEV_TOKENS;
+    const devTokensEnabled = devTokensSetting ? devTokensSetting === 'true' : true;
 
-  if (devTokensEnabled) {
-    verifiers.push(new DevTokenVerifier());
+    if (devTokensEnabled) {
+      verifiers.push(new DevTokenVerifier());
+      console.log('[auth] Dev token verifier enabled (non-production)');
+    }
+  }
+
+  // Warn if no verifiers are registered
+  if (verifiers.length === 0) {
+    console.warn(
+      '[auth] WARNING: No token verifiers registered. All authenticated requests will be rejected.',
+    );
   }
 
   return verifiers;

--- a/apps/server/src/middleware/auth.ts
+++ b/apps/server/src/middleware/auth.ts
@@ -37,6 +37,10 @@ export function createAuthMiddleware(verifiers: TokenVerifier[]) {
       throw new UnauthorizedError('Empty bearer token');
     }
 
+    if (token.length > 8192) {
+      throw new UnauthorizedError('Token exceeds maximum length');
+    }
+
     for (const verifier of verifiers) {
       const result = await verifier.verify(token);
       if (result) {

--- a/apps/server/src/middleware/rate-limit.ts
+++ b/apps/server/src/middleware/rate-limit.ts
@@ -19,7 +19,11 @@ import { TooManyRequestsError } from '../utils/errors.js';
 export function createRateLimitMiddleware(limiter: RateLimiter, tier?: RateLimitTier) {
   return createMiddleware<AppEnv>(async (c, next) => {
     const userId = c.get('userId');
-    const key = userId || c.req.header('X-Forwarded-For') || 'anonymous';
+    if (!userId) {
+      // Rate limiter requires auth middleware to run first
+      throw new TooManyRequestsError('Rate limiting requires authentication');
+    }
+    const key = userId;
 
     const result = limiter.check(key, tier);
 

--- a/apps/server/src/services/claude.ts
+++ b/apps/server/src/services/claude.ts
@@ -142,6 +142,15 @@ const DETECT_FIELDS_TOOL: Anthropic.Tool = {
   },
 };
 
+// ─── Helpers ───────────────────────────────────────────────────
+
+/** Strip control characters and limit length of OCR text to prevent prompt injection. */
+function sanitizeOcrText(text: string): string {
+  return text
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '') // strip control chars
+    .slice(0, 500); // limit per-block length
+}
+
 // ─── Service ───────────────────────────────────────────────────────
 
 export interface ClaudeServiceConfig {
@@ -179,6 +188,7 @@ export class ClaudeService {
    * mapped to profile field paths.
    */
   async analyzeDocument(request: AnalyzeRequest): Promise<AnalyzeResponse> {
+    this.validateRequest(request);
     const userContent = this.buildUserMessage(request);
 
     const response = await this.client.messages.create({
@@ -210,6 +220,31 @@ export class ClaudeService {
 
   // ─── Private ───────────────────────────────────────────────────
 
+  private validateRequest(request: AnalyzeRequest): void {
+    if (request.pages.length === 0) {
+      throw new Error('At least one page is required');
+    }
+    if (request.pages.length > 20) {
+      throw new Error('Maximum 20 pages per request');
+    }
+    for (const page of request.pages) {
+      // ~10MB base64 limit per image
+      if (page.imageBase64.length > 14_000_000) {
+        throw new Error(`Page ${page.pageNumber}: image exceeds 10MB limit`);
+      }
+      if (page.ocrBlocks.length > 500) {
+        throw new Error(`Page ${page.pageNumber}: maximum 500 OCR blocks per page`);
+      }
+    }
+    // Validate field names — alphanumeric, dots, brackets, underscores only
+    const fieldNamePattern = /^[\w.[\]]{1,100}$/;
+    for (const field of request.availableFields) {
+      if (!fieldNamePattern.test(field)) {
+        throw new Error(`Invalid field name: ${field.slice(0, 50)}`);
+      }
+    }
+  }
+
   private buildUserMessage(
     request: AnalyzeRequest,
   ): Array<Anthropic.ImageBlockParam | Anthropic.TextBlockParam> {
@@ -218,7 +253,7 @@ export class ClaudeService {
     // Add available fields context
     content.push({
       type: 'text',
-      text: `Available profile fields for matching:\n${request.availableFields.join('\n')}\n\nAnalyze the following document pages:`,
+      text: `<available_fields>\n${request.availableFields.join('\n')}\n</available_fields>\n\nAnalyze the following document pages:`,
     });
 
     // Add each page's image and OCR data
@@ -236,13 +271,13 @@ export class ClaudeService {
         const ocrText = page.ocrBlocks
           .map(
             (b) =>
-              `"${b.text}" at (${b.bounds.x.toFixed(3)}, ${b.bounds.y.toFixed(3)}, ${b.bounds.width.toFixed(3)}, ${b.bounds.height.toFixed(3)}) conf=${b.confidence.toFixed(2)}`,
+              `"${sanitizeOcrText(b.text)}" at (${b.bounds.x.toFixed(3)}, ${b.bounds.y.toFixed(3)}, ${b.bounds.width.toFixed(3)}, ${b.bounds.height.toFixed(3)}) conf=${b.confidence.toFixed(2)}`,
           )
           .join('\n');
 
         content.push({
           type: 'text',
-          text: `Page ${page.pageNumber} OCR blocks (normalized 0-1 coordinates):\n${ocrText}`,
+          text: `<ocr_blocks page="${page.pageNumber}">\n${ocrText}\n</ocr_blocks>`,
         });
       }
     }

--- a/apps/server/src/services/rate-limiter.ts
+++ b/apps/server/src/services/rate-limiter.ts
@@ -48,26 +48,36 @@ export class RateLimiter {
   /**
    * Check and consume a rate limit token for the given key.
    *
-   * Prunes expired timestamps, then checks if the request is within
-   * the limit. If allowed, records the new timestamp.
+   * Prunes expired timestamps and evicts empty records to prevent
+   * unbounded memory growth. Checks if the request is within the
+   * limit, and if allowed, records the new timestamp.
    */
   check(key: string, tier?: RateLimitTier): RateLimitResult {
     const { maxRequests, windowMs } = tier ?? this.defaultTier;
     const now = Date.now();
     const windowStart = now - windowMs;
 
-    let record = this.records.get(key);
-    if (!record) {
-      record = { timestamps: [] };
-      this.records.set(key, record);
+    const record = this.records.get(key);
+
+    if (record) {
+      // Prune expired timestamps
+      record.timestamps = record.timestamps.filter((t) => t > windowStart);
+
+      // Evict empty records to prevent unbounded memory growth
+      if (record.timestamps.length === 0) {
+        this.records.delete(key);
+      }
     }
 
-    // Prune expired timestamps
-    record.timestamps = record.timestamps.filter((t) => t > windowStart);
+    const active = this.records.get(key);
+    const currentCount = active?.timestamps.length ?? 0;
 
-    const resetAt = Math.ceil((now + windowMs) / 1000);
+    const resetAt =
+      active && active.timestamps.length > 0
+        ? Math.ceil((active.timestamps[0]! + windowMs) / 1000)
+        : Math.ceil((now + windowMs) / 1000);
 
-    if (record.timestamps.length >= maxRequests) {
+    if (currentCount >= maxRequests) {
       return {
         allowed: false,
         limit: maxRequests,
@@ -76,13 +86,17 @@ export class RateLimiter {
       };
     }
 
-    // Consume a token
-    record.timestamps.push(now);
+    // Consume a token — create record if needed
+    if (!active) {
+      this.records.set(key, { timestamps: [now] });
+    } else {
+      active.timestamps.push(now);
+    }
 
     return {
       allowed: true,
       limit: maxRequests,
-      remaining: maxRequests - record.timestamps.length,
+      remaining: maxRequests - (currentCount + 1),
       resetAt,
     };
   }


### PR DESCRIPTION
## Summary

Retroactive code review + security audit of S-47, S-48, S-49, S-66, S-68, S-69 found 4 critical and 16 high issues. This PR fixes all of them.

## Security Fixes (Server)

| Finding | Fix |
|---------|-----|
| Dev tokens could be force-enabled in production | Hard-block in production regardless of env vars |
| Dev verifier accepted arbitrary user IDs | Added regex validation (alphanumeric, max 128 chars) |
| Google/Apple verifiers silently swallowed infra errors | Log non-validation errors at warn level |
| No warning when zero verifiers registered | Log warning at startup |
| No token length limit (DoS vector) | Reject tokens > 8KB |
| X-Forwarded-For fallback was spoofable | Removed — require userId from auth |
| Rate limiter never evicted empty records (memory leak) | Delete records after timestamp pruning |
| No input validation on Claude API requests | Limit pages (20), image size (10MB), OCR blocks (500) |
| OCR text injected into prompt unsanitized | Strip control chars, limit length, XML delimiters |
| Field names injected without validation | Regex allowlist for field name format |

## Quality Fixes (Mobile)

| Finding | Fix |
|---------|-----|
| SignaturePad stale closure in gesture callbacks | Use refs for color/width in gesture handlers |
| No stroke count limit (memory) | Max 200 strokes |
| View used as button for pickers (accessibility) | Replaced with Pressable |
| Color hex codes as accessibility labels | Human-readable names (Black, Dark Blue, etc.) |
| FieldEditorSheet no modal accessibility | Added accessibilityViewIsModal |
| Backdrop no accessibility label | Added "Close field editor" label |
| Field value not trimmed on save | Added .trim() |
| No input length limits | maxLength 500 (field editor), 100 (signature) |

## Remaining (medium/low, tracked for future)
- Keyboard avoidance on FieldEditorSheet
- Live stroke preview on SignaturePad
- Runtime schema validation on Claude response
- Retry-After header on 429 responses
- Behavioral test coverage (exports-only tests flagged)

## Test Plan
- [x] 70 server tests passing
- [x] 18 mobile component tests passing
- [x] TypeScript clean on both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)