### PR TITLE
feat(server): add document fingerprinting service (S-51)

### DIFF
--- a/apps/server/src/__tests__/fingerprint.test.ts
+++ b/apps/server/src/__tests__/fingerprint.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+import {
+  quantize,
+  boxToToken,
+  generateFingerprint,
+  fingerprintFromOcrBlocks,
+  type FingerprintInput,
+  type LayoutBox,
+} from '../services/fingerprint.js';
+
+// ─── quantize ──────────────────────────────────────────────────────
+
+describe('quantize', () => {
+  it('should map 0 to 0', () => {
+    expect(quantize(0)).toBe(0);
+  });
+
+  it('should map 1 to GRID_SIZE (50)', () => {
+    expect(quantize(1)).toBe(50);
+  });
+
+  it('should map 0.5 to 25', () => {
+    expect(quantize(0.5)).toBe(25);
+  });
+
+  it('should round to nearest grid cell', () => {
+    expect(quantize(0.01)).toBe(1); // 0.5 rounds to 1
+    expect(quantize(0.02)).toBe(1);
+    expect(quantize(0.03)).toBe(2); // 1.5 rounds to 2
+  });
+
+  it('should clamp values below 0', () => {
+    expect(quantize(-0.1)).toBe(0);
+    expect(quantize(-1)).toBe(0);
+  });
+
+  it('should clamp values above 1', () => {
+    expect(quantize(1.1)).toBe(50);
+    expect(quantize(2)).toBe(50);
+  });
+});
+
+// ─── boxToToken ────────────────────────────────────────────────────
+
+describe('boxToToken', () => {
+  it('should produce quantized comma-separated token', () => {
+    const box: LayoutBox = { x: 0.1, y: 0.2, width: 0.3, height: 0.05 };
+    const token = boxToToken(box);
+    // 0.1*50=5, 0.2*50=10, 0.3*50=15, 0.05*50=2.5→3
+    expect(token).toBe('5,10,15,3');
+  });
+
+  it('should produce same token for slightly different positions within same grid cell', () => {
+    const box1: LayoutBox = { x: 0.1, y: 0.2, width: 0.3, height: 0.06 };
+    const box2: LayoutBox = { x: 0.104, y: 0.198, width: 0.302, height: 0.058 };
+    expect(boxToToken(box1)).toBe(boxToToken(box2));
+  });
+
+  it('should produce different tokens for significantly different positions', () => {
+    const box1: LayoutBox = { x: 0.1, y: 0.2, width: 0.3, height: 0.05 };
+    const box2: LayoutBox = { x: 0.5, y: 0.8, width: 0.3, height: 0.05 };
+    expect(boxToToken(box1)).not.toBe(boxToToken(box2));
+  });
+});
+
+// ─── generateFingerprint ───────────────────────────────────────────
+
+describe('generateFingerprint', () => {
+  const sampleInput: FingerprintInput = {
+    pageCount: 2,
+    pages: [
+      {
+        pageNumber: 1,
+        boxes: [
+          { x: 0.1, y: 0.1, width: 0.3, height: 0.04 },
+          { x: 0.1, y: 0.2, width: 0.3, height: 0.04 },
+          { x: 0.5, y: 0.1, width: 0.3, height: 0.04 },
+        ],
+      },
+      {
+        pageNumber: 2,
+        boxes: [{ x: 0.1, y: 0.1, width: 0.4, height: 0.05 }],
+      },
+    ],
+  };
+
+  it('should return a 64-character hex SHA-256 hash', () => {
+    const result = generateFingerprint(sampleInput);
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('should return the correct box count', () => {
+    const result = generateFingerprint(sampleInput);
+    expect(result.boxCount).toBe(4);
+  });
+
+  it('should produce identical fingerprints for identical layouts', () => {
+    const r1 = generateFingerprint(sampleInput);
+    const r2 = generateFingerprint(sampleInput);
+    expect(r1.hash).toBe(r2.hash);
+  });
+
+  it('should produce identical fingerprints regardless of box order', () => {
+    const input1: FingerprintInput = {
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [
+            { x: 0.1, y: 0.1, width: 0.3, height: 0.04 },
+            { x: 0.5, y: 0.5, width: 0.2, height: 0.06 },
+          ],
+        },
+      ],
+    };
+    const input2: FingerprintInput = {
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [
+            { x: 0.5, y: 0.5, width: 0.2, height: 0.06 },
+            { x: 0.1, y: 0.1, width: 0.3, height: 0.04 },
+          ],
+        },
+      ],
+    };
+    expect(generateFingerprint(input1).hash).toBe(generateFingerprint(input2).hash);
+  });
+
+  it('should absorb minor scan variations (same template)', () => {
+    const scan1: FingerprintInput = {
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [
+            { x: 0.1, y: 0.2, width: 0.3, height: 0.06 },
+            { x: 0.1, y: 0.4, width: 0.3, height: 0.06 },
+          ],
+        },
+      ],
+    };
+    const scan2: FingerprintInput = {
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [
+            { x: 0.104, y: 0.198, width: 0.302, height: 0.058 },
+            { x: 0.098, y: 0.402, width: 0.298, height: 0.062 },
+          ],
+        },
+      ],
+    };
+    expect(generateFingerprint(scan1).hash).toBe(generateFingerprint(scan2).hash);
+  });
+
+  it('should produce different fingerprints for different layouts', () => {
+    const formA: FingerprintInput = {
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [
+            { x: 0.1, y: 0.1, width: 0.3, height: 0.04 },
+            { x: 0.1, y: 0.2, width: 0.3, height: 0.04 },
+          ],
+        },
+      ],
+    };
+    const formB: FingerprintInput = {
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [
+            { x: 0.1, y: 0.1, width: 0.8, height: 0.04 },
+            { x: 0.1, y: 0.5, width: 0.4, height: 0.1 },
+            { x: 0.5, y: 0.5, width: 0.4, height: 0.1 },
+          ],
+        },
+      ],
+    };
+    expect(generateFingerprint(formA).hash).not.toBe(generateFingerprint(formB).hash);
+  });
+
+  it('should produce different fingerprints for different page counts', () => {
+    const onePage: FingerprintInput = {
+      pageCount: 1,
+      pages: [{ pageNumber: 1, boxes: [{ x: 0.1, y: 0.1, width: 0.3, height: 0.04 }] }],
+    };
+    const twoPages: FingerprintInput = {
+      pageCount: 2,
+      pages: [{ pageNumber: 1, boxes: [{ x: 0.1, y: 0.1, width: 0.3, height: 0.04 }] }],
+    };
+    expect(generateFingerprint(onePage).hash).not.toBe(generateFingerprint(twoPages).hash);
+  });
+
+  it('should deduplicate identical boxes on the same page', () => {
+    const withDupes: FingerprintInput = {
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [
+            { x: 0.1, y: 0.1, width: 0.3, height: 0.04 },
+            { x: 0.1, y: 0.1, width: 0.3, height: 0.04 },
+          ],
+        },
+      ],
+    };
+    const result = generateFingerprint(withDupes);
+    expect(result.boxCount).toBe(1); // deduped
+  });
+
+  it('should handle empty pages gracefully', () => {
+    const empty: FingerprintInput = {
+      pageCount: 1,
+      pages: [{ pageNumber: 1, boxes: [] }],
+    };
+    const result = generateFingerprint(empty);
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.boxCount).toBe(0);
+  });
+
+  it('should handle no pages gracefully', () => {
+    const noPages: FingerprintInput = { pageCount: 0, pages: [] };
+    const result = generateFingerprint(noPages);
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.boxCount).toBe(0);
+  });
+});
+
+// ─── fingerprintFromOcrBlocks ──────────────────────────────────────
+
+describe('fingerprintFromOcrBlocks', () => {
+  it('should extract bounds from OCR blocks and fingerprint', () => {
+    const result = fingerprintFromOcrBlocks([
+      {
+        pageNumber: 1,
+        ocrBlocks: [
+          { bounds: { x: 0.1, y: 0.1, width: 0.3, height: 0.04 } },
+          { bounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.04 } },
+        ],
+      },
+    ]);
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.boxCount).toBe(2);
+  });
+
+  it('should produce same result as generateFingerprint with equivalent input', () => {
+    const ocrResult = fingerprintFromOcrBlocks([
+      {
+        pageNumber: 1,
+        ocrBlocks: [{ bounds: { x: 0.5, y: 0.5, width: 0.2, height: 0.06 } }],
+      },
+    ]);
+    const directResult = generateFingerprint({
+      pageCount: 1,
+      pages: [
+        {
+          pageNumber: 1,
+          boxes: [{ x: 0.5, y: 0.5, width: 0.2, height: 0.06 }],
+        },
+      ],
+    });
+    expect(ocrResult.hash).toBe(directResult.hash);
+  });
+});

--- a/apps/server/src/services/fingerprint.ts
+++ b/apps/server/src/services/fingerprint.ts
@@ -1,0 +1,137 @@
+/**
+ * Document fingerprinting service.
+ *
+ * Generates a stable hash from a document's structural layout (bounding
+ * box positions and page count) so that repeat scans of the same form
+ * template produce the same fingerprint regardless of filled-in content.
+ *
+ * Used as a cache key in the template cache (S-52) to skip redundant
+ * Claude API calls for known form templates.
+ */
+
+import { createHash } from 'node:crypto';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+/** A bounding box from OCR data, with normalized 0-1 coordinates. */
+export interface LayoutBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** OCR layout data for a single page. */
+export interface PageLayout {
+  pageNumber: number;
+  boxes: LayoutBox[];
+}
+
+/** Input for fingerprint generation. */
+export interface FingerprintInput {
+  /** Total number of pages in the document. */
+  pageCount: number;
+  /** Layout data per page. */
+  pages: PageLayout[];
+}
+
+/** Result of fingerprint generation. */
+export interface FingerprintResult {
+  /** The hex-encoded SHA-256 fingerprint. */
+  hash: string;
+  /** Number of layout boxes included in the hash. */
+  boxCount: number;
+}
+
+// ─── Constants ─────────────────────────────────────────────────────
+
+/**
+ * Quantization grid size for bounding box coordinates.
+ *
+ * Coordinates are snapped to a grid of this many cells per axis.
+ * A 50x50 grid means each cell is 2% of the page, which absorbs
+ * minor scan alignment variations while distinguishing different
+ * form layouts.
+ */
+const GRID_SIZE = 50;
+
+// ─── Core ──────────────────────────────────────────────────────────
+
+/**
+ * Quantize a normalized coordinate (0-1) to a grid cell index.
+ *
+ * Clamps the value to [0, 1] before quantizing to handle slight
+ * OCR overshoot at page edges.
+ */
+export function quantize(value: number): number {
+  const clamped = Math.max(0, Math.min(1, value));
+  return Math.round(clamped * GRID_SIZE);
+}
+
+/**
+ * Convert a bounding box to a quantized string token.
+ *
+ * Format: "x,y,w,h" where each value is a grid cell index.
+ * This absorbs minor positional variations from scanning while
+ * preserving the structural layout.
+ */
+export function boxToToken(box: LayoutBox): string {
+  return `${quantize(box.x)},${quantize(box.y)},${quantize(box.width)},${quantize(box.height)}`;
+}
+
+/**
+ * Generate a fingerprint for a document's structural layout.
+ *
+ * The fingerprint is based on:
+ * 1. Total page count
+ * 2. Quantized bounding box positions per page (sorted for stability)
+ *
+ * Text content is deliberately excluded — only the spatial layout
+ * of fields matters. This means the same form template produces
+ * the same fingerprint whether it's blank or filled in.
+ */
+export function generateFingerprint(input: FingerprintInput): FingerprintResult {
+  const parts: string[] = [];
+  let boxCount = 0;
+
+  // Include page count as a top-level discriminator
+  parts.push(`pages:${input.pageCount}`);
+
+  // Process each page's layout
+  for (const page of input.pages) {
+    const tokens = page.boxes.map(boxToToken);
+    // Sort tokens for position-independent stability
+    tokens.sort();
+    // Deduplicate identical tokens (overlapping OCR blocks)
+    const unique = [...new Set(tokens)];
+
+    parts.push(`p${page.pageNumber}:${unique.join('|')}`);
+    boxCount += unique.length;
+  }
+
+  const payload = parts.join('\n');
+  const hash = createHash('sha256').update(payload).digest('hex');
+
+  return { hash, boxCount };
+}
+
+/**
+ * Generate a fingerprint from raw OCR block data.
+ *
+ * Convenience wrapper that extracts bounding boxes from OCR blocks
+ * matching the shape used in the Claude service.
+ */
+export function fingerprintFromOcrBlocks(
+  pages: Array<{
+    pageNumber: number;
+    ocrBlocks: Array<{ bounds: LayoutBox }>;
+  }>,
+): FingerprintResult {
+  return generateFingerprint({
+    pageCount: pages.length,
+    pages: pages.map((p) => ({
+      pageNumber: p.pageNumber,
+      boxes: p.ocrBlocks.map((b) => b.bounds),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- **Document fingerprinting service** — generates stable SHA-256 hashes from document layout structure
- Same form template produces identical fingerprints regardless of filled-in content
- Enables cache-based reuse of Claude API results for repeated forms (S-52)
- No external dependencies — uses Node.js built-in `crypto`

Closes #52

## How It Works
```
OCR bounding boxes → quantize to 50x50 grid → sort + deduplicate → SHA-256 hash
```

The quantization grid absorbs minor scan alignment variations (~2% per cell), so the same form scanned twice with slight positioning differences produces the same fingerprint.

## Acceptance Criteria
- [x] Layout-based hashing (ignoring content, focusing on structure)
- [x] Consistent fingerprints for same form templates
- [x] Different fingerprints for different forms

## Security Review
- Operates on numeric coordinates only — no user-facing strings
- Uses SHA-256 (cryptographic hash) for collision resistance
- No external dependencies or network calls

## Test Plan
- [x] 21 new tests (quantize, boxToToken, fingerprint generation, edge cases)
- [x] 91 total server tests passing (no regressions)
- [x] TypeScript clean, Prettier formatted
- [x] Tests verify: stability, order independence, scan variation absorption, deduplication, different forms produce different hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)