### PR TITLE
feat(mobile): add backend proxy API client (S-59)

### DIFF
--- a/apps/mobile/src/services/api/__tests__/client.test.ts
+++ b/apps/mobile/src/services/api/__tests__/client.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ApiClient, ApiError, NetworkError } from '../client.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock config
+vi.mock('../config.js', () => ({
+  API_BASE_URL: 'https://api.test.com',
+  API_TIMEOUT_MS: 5000,
+  ANALYZE_TIMEOUT_MS: 30000,
+}));
+
+describe('ApiClient', () => {
+  let client: ApiClient;
+  const mockGetToken = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockGetToken.mockReset();
+    mockGetToken.mockResolvedValue('test-token-123');
+    client = new ApiClient({ getAuthToken: mockGetToken });
+  });
+
+  describe('get', () => {
+    it('should make authenticated GET request', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: 'result' }),
+      });
+
+      const result = await client.get('/api/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.test.com/api/test',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token-123',
+          }),
+        }),
+      );
+      expect(result).toEqual({ data: 'result' });
+    });
+  });
+
+  describe('post', () => {
+    it('should make authenticated POST request with JSON body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      });
+
+      const body = { pages: [], availableFields: ['firstName'] };
+      await client.post('/api/analyze', body);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.test.com/api/analyze',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-token-123',
+          }),
+          body: JSON.stringify(body),
+        }),
+      );
+    });
+  });
+
+  describe('auth token', () => {
+    it('should throw ApiError when no token is available', async () => {
+      mockGetToken.mockResolvedValue(null);
+
+      await expect(client.get('/api/test')).rejects.toThrow(ApiError);
+      await expect(client.get('/api/test')).rejects.toThrow('No authentication token');
+    });
+
+    it('should call getAuthToken for each request', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await client.get('/api/a');
+      await client.get('/api/b');
+
+      expect(mockGetToken).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw ApiError with status and message on HTTP error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: () =>
+          Promise.resolve({
+            error: { code: 'TOO_MANY_REQUESTS', message: 'Rate limit exceeded' },
+          }),
+      });
+
+      try {
+        await client.get('/api/test');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).statusCode).toBe(429);
+        expect((err as ApiError).code).toBe('TOO_MANY_REQUESTS');
+        expect((err as ApiError).message).toBe('Rate limit exceeded');
+      }
+    });
+
+    it('should handle non-JSON error responses', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error('not JSON')),
+      });
+
+      try {
+        await client.get('/api/test');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).statusCode).toBe(500);
+        expect((err as ApiError).message).toContain('500');
+      }
+    });
+
+    it('should throw NetworkError on fetch failure', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Network request failed'));
+
+      await expect(client.get('/api/test')).rejects.toThrow(NetworkError);
+    });
+
+    it('should throw NetworkError on timeout', async () => {
+      mockFetch.mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            setTimeout(() => reject(new DOMException('Aborted', 'AbortError')), 10);
+          }),
+      );
+
+      const shortClient = new ApiClient({
+        getAuthToken: mockGetToken,
+        timeoutMs: 1,
+      });
+
+      await expect(shortClient.get('/api/test')).rejects.toThrow(NetworkError);
+    });
+  });
+
+  describe('configuration', () => {
+    it('should use custom base URL', async () => {
+      const customClient = new ApiClient({
+        baseUrl: 'https://custom.api.com',
+        getAuthToken: mockGetToken,
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await customClient.get('/api/test');
+
+      expect(mockFetch).toHaveBeenCalledWith('https://custom.api.com/api/test', expect.anything());
+    });
+
+    it('should allow per-request timeout override', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await client.get('/api/test', { timeoutMs: 60000 });
+      // If it doesn't throw, the timeout was accepted
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('should merge additional headers', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await client.get('/api/test', { headers: { 'X-Custom': 'value' } });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'X-Custom': 'value' }),
+        }),
+      );
+    });
+  });
+});
+
+describe('analyzeDocument', () => {
+  it('should call POST /api/analyze with correct timeout', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          data: { fields: [], documentType: 'test' },
+          meta: { cached: false, fingerprint: 'abc', boxCount: 0 },
+        }),
+    });
+
+    const mockGetToken = vi.fn().mockResolvedValue('token');
+    const client = new ApiClient({ getAuthToken: mockGetToken });
+
+    const { analyzeDocument } = await import('../analyzeService.js');
+    const result = await analyzeDocument(client, {
+      pages: [{ pageNumber: 1, imageBase64: 'dGVzdA==', ocrBlocks: [] }],
+      availableFields: ['firstName'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.fields).toEqual([]);
+    expect(result.meta.fingerprint).toBe('abc');
+  });
+});

--- a/apps/mobile/src/services/api/analyzeService.ts
+++ b/apps/mobile/src/services/api/analyzeService.ts
@@ -1,0 +1,96 @@
+/**
+ * Mobile client for the document analysis API.
+ *
+ * Wraps the backend POST /api/analyze endpoint with typed
+ * request/response handling and the longer timeout needed
+ * for image upload + Claude API processing.
+ */
+
+import type { DetectedFieldType } from '@fillit/shared';
+import { ApiClient, type ApiRequestOptions } from './client.js';
+import { ANALYZE_TIMEOUT_MS } from './config.js';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface AnalyzePageInput {
+  pageNumber: number;
+  imageBase64: string;
+  ocrBlocks: Array<{
+    text: string;
+    bounds: { x: number; y: number; width: number; height: number };
+    confidence: number;
+  }>;
+}
+
+export interface AnalyzeRequestInput {
+  pages: AnalyzePageInput[];
+  availableFields: string[];
+}
+
+export interface AnalyzedField {
+  id: string;
+  pageNumber: number;
+  label: string;
+  fieldType: DetectedFieldType;
+  bounds: { x: number; y: number; width: number; height: number };
+  matchedField: string | null;
+  matchConfidence: number;
+  notes?: string;
+}
+
+export interface AnalyzeResponseData {
+  fields: AnalyzedField[];
+  documentType?: string;
+  documentLanguage?: string;
+}
+
+export interface AnalyzeResult {
+  success: boolean;
+  data: AnalyzeResponseData;
+  meta: {
+    cached: boolean;
+    fingerprint: string;
+    boxCount: number;
+    usage?: {
+      inputTokens: number;
+      outputTokens: number;
+      requests: number;
+    };
+  };
+}
+
+// ─── Service ───────────────────────────────────────────────────────
+
+/**
+ * Submit document pages for AI field detection.
+ *
+ * Sends page images + OCR bounding boxes to the backend analyze
+ * endpoint. The backend handles fingerprinting, cache lookup,
+ * and Claude API calls.
+ *
+ * @param client - Authenticated API client instance.
+ * @param input - Pages with images and OCR data, plus available profile fields.
+ * @returns Detected fields with bounding boxes and confidence scores.
+ */
+export async function analyzeDocument(
+  client: ApiClient,
+  input: AnalyzeRequestInput,
+): Promise<AnalyzeResult> {
+  const options: ApiRequestOptions = {
+    timeoutMs: ANALYZE_TIMEOUT_MS,
+  };
+
+  return client.post<AnalyzeResult>('/api/analyze', input, options);
+}
+
+/**
+ * Get template cache statistics from the backend.
+ */
+export async function getCacheStats(
+  client: ApiClient,
+): Promise<{
+  success: boolean;
+  data: { size: number; hits: number; misses: number; evictions: number };
+}> {
+  return client.get('/api/analyze/cache/stats');
+}

--- a/apps/mobile/src/services/api/client.ts
+++ b/apps/mobile/src/services/api/client.ts
@@ -1,0 +1,137 @@
+/**
+ * HTTP client for the FillIt backend API.
+ *
+ * Thin wrapper around fetch with auth token injection, timeout,
+ * structured error handling, and typed response parsing.
+ */
+
+import { API_BASE_URL, API_TIMEOUT_MS } from './config.js';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface ApiClientConfig {
+  /** Override base URL. */
+  baseUrl?: string;
+  /** Default timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Function that returns the current auth token. */
+  getAuthToken: () => Promise<string | null>;
+}
+
+export interface ApiRequestOptions {
+  /** Override timeout for this request. */
+  timeoutMs?: number;
+  /** Additional headers. */
+  headers?: Record<string, string>;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public statusCode: number,
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export class NetworkError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'NetworkError';
+    this.cause = cause;
+  }
+}
+
+// ─── Client ────────────────────────────────────────────────────────
+
+export class ApiClient {
+  private baseUrl: string;
+  private defaultTimeout: number;
+  private getAuthToken: () => Promise<string | null>;
+
+  constructor(config: ApiClientConfig) {
+    this.baseUrl = config.baseUrl ?? API_BASE_URL;
+    this.defaultTimeout = config.timeoutMs ?? API_TIMEOUT_MS;
+    this.getAuthToken = config.getAuthToken;
+  }
+
+  /**
+   * Make an authenticated GET request.
+   */
+  async get<T>(path: string, options?: ApiRequestOptions): Promise<T> {
+    return this.request<T>('GET', path, undefined, options);
+  }
+
+  /**
+   * Make an authenticated POST request with JSON body.
+   */
+  async post<T>(path: string, body: unknown, options?: ApiRequestOptions): Promise<T> {
+    return this.request<T>('POST', path, body, options);
+  }
+
+  // ─── Private ───────────────────────────────────────────────────
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options?: ApiRequestOptions,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const timeoutMs = options?.timeoutMs ?? this.defaultTimeout;
+
+    // Get auth token
+    const token = await this.getAuthToken();
+    if (!token) {
+      throw new ApiError(401, 'NO_AUTH_TOKEN', 'No authentication token available');
+    }
+
+    // Build headers
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      ...options?.headers,
+    };
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    // Create abort controller for timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => null);
+        const message =
+          (errorBody as any)?.error?.message ??
+          (errorBody as any)?.error ??
+          `Request failed with status ${response.status}`;
+        const code = (errorBody as any)?.error?.code ?? `HTTP_${response.status}`;
+        throw new ApiError(response.status, code, message);
+      }
+
+      return (await response.json()) as T;
+    } catch (err) {
+      clearTimeout(timeoutId);
+
+      if (err instanceof ApiError) throw err;
+
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw new NetworkError(`Request timeout after ${timeoutMs}ms: ${method} ${path}`);
+      }
+
+      throw new NetworkError(`Network request failed: ${method} ${path}`, err);
+    }
+  }
+}

--- a/apps/mobile/src/services/api/config.ts
+++ b/apps/mobile/src/services/api/config.ts
@@ -1,0 +1,20 @@
+/**
+ * API client configuration.
+ *
+ * Reads the server URL from Expo environment variables.
+ * Falls back to localhost for development.
+ */
+
+import Constants from 'expo-constants';
+
+/** Base URL for the FillIt backend API. */
+export const API_BASE_URL: string =
+  (Constants.expoConfig?.extra?.apiUrl as string) ??
+  process.env.EXPO_PUBLIC_API_URL ??
+  'http://localhost:3000';
+
+/** Default request timeout in milliseconds. */
+export const API_TIMEOUT_MS = 30_000;
+
+/** Maximum request timeout for analyze (image upload is slow). */
+export const ANALYZE_TIMEOUT_MS = 120_000;

--- a/apps/mobile/src/services/api/index.ts
+++ b/apps/mobile/src/services/api/index.ts
@@ -1,0 +1,11 @@
+export { API_BASE_URL, API_TIMEOUT_MS, ANALYZE_TIMEOUT_MS } from './config.js';
+export { ApiClient, ApiError, NetworkError } from './client.js';
+export type { ApiClientConfig, ApiRequestOptions } from './client.js';
+export { analyzeDocument, getCacheStats } from './analyzeService.js';
+export type {
+  AnalyzePageInput,
+  AnalyzeRequestInput,
+  AnalyzedField,
+  AnalyzeResponseData,
+  AnalyzeResult,
+} from './analyzeService.js';


### PR DESCRIPTION
## Summary
- **ApiClient** — authenticated HTTP client with Bearer token injection, configurable timeout, abort-on-timeout, and structured error handling
- **analyzeDocument()** — typed wrapper for POST /api/analyze with extended 120s timeout for image upload + Claude processing
- **getCacheStats()** — template cache monitoring endpoint wrapper
- **ApiError / NetworkError** — distinct error types for HTTP errors vs network failures

Closes #60

## How It Works
```
Mobile app
  → ApiClient.post('/api/analyze', { pages, availableFields })
    → Authorization: Bearer <token>
    → Timeout: 120s (configurable)
    → Response parsed to typed AnalyzeResult
    → ApiError on 4xx/5xx, NetworkError on timeout/fetch failure
```

## Acceptance Criteria
- [x] HTTP client with auth token header
- [x] POST /analyze with image data
- [x] Response parsing to typed objects
- [x] Network error handling (ApiError, NetworkError)
- [x] Timeout configuration (default 30s, analyze 120s, per-request override)

## Configuration
Set `EXPO_PUBLIC_API_URL` in the mobile app's environment, or it defaults to `http://localhost:3000`.

## Test Plan
- [x] 12 tests (auth injection, GET/POST, error handling, timeout, config)
- [x] TypeScript clean, Prettier formatted
- [x] Tests cover: auth token flow, HTTP errors, non-JSON errors, network failures, timeout, custom base URL, header merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)