### PR TITLE
feat(mobile): add network-aware AI routing service (S-63)

### DIFF
--- a/apps/mobile/src/services/ai/__tests__/aiRouter.test.ts
+++ b/apps/mobile/src/services/ai/__tests__/aiRouter.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock network status
+const mockIsOnline = vi.fn();
+vi.mock('../networkStatus.js', () => ({
+  isOnline: () => mockIsOnline(),
+}));
+
+// Mock API analyze
+const mockAnalyzeDocument = vi.fn();
+vi.mock('../../api/analyzeService.js', () => ({
+  analyzeDocument: (...args: unknown[]) => mockAnalyzeDocument(...args),
+}));
+
+// Mock offline detection
+const mockDetectFieldsOffline = vi.fn();
+vi.mock('../offlineDetection.js', () => ({
+  detectFieldsOffline: (...args: unknown[]) => mockDetectFieldsOffline(...args),
+}));
+
+import { detectFields, type AiRouterConfig } from '../aiRouter.js';
+import { ApiClient } from '../../api/client.js';
+
+describe('detectFields', () => {
+  const mockClient = {} as ApiClient;
+  const config: AiRouterConfig = {
+    client: mockClient,
+    availableFields: ['firstName', 'lastName'],
+  };
+
+  const pages = [
+    {
+      pageNumber: 1,
+      imageBase64: 'dGVzdA==',
+      ocrBlocks: [
+        {
+          text: 'First Name',
+          bounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.05 },
+          confidence: 0.95,
+        },
+      ],
+    },
+  ];
+
+  const cloudFields = [
+    {
+      id: 'field-1',
+      pageNumber: 1,
+      label: 'First Name',
+      fieldType: 'text' as const,
+      bounds: { x: 0.1, y: 0.25, width: 0.3, height: 0.04 },
+      matchedField: 'firstName',
+      matchConfidence: 0.92,
+    },
+  ];
+
+  const offlineFields = [
+    {
+      id: 'offline-field-0',
+      pageNumber: 1,
+      label: 'First Name',
+      fieldType: 'text' as const,
+      bounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.05 },
+      matchedField: 'firstName',
+      matchConfidence: 0.9,
+      matchMethod: 'exact' as const,
+    },
+  ];
+
+  beforeEach(() => {
+    mockIsOnline.mockReset();
+    mockAnalyzeDocument.mockReset();
+    mockDetectFieldsOffline.mockReset();
+  });
+
+  it('should use cloud API when online', async () => {
+    mockIsOnline.mockResolvedValue(true);
+    mockAnalyzeDocument.mockResolvedValue({
+      success: true,
+      data: { fields: cloudFields, documentType: 'form' },
+      meta: { cached: false, fingerprint: 'abc123', boxCount: 5 },
+    });
+
+    const result = await detectFields(config, pages);
+
+    expect(result.method).toBe('cloud');
+    expect(result.reducedAccuracy).toBe(false);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0]!.matchedField).toBe('firstName');
+    expect(result.fingerprint).toBe('abc123');
+    expect(mockAnalyzeDocument).toHaveBeenCalledOnce();
+    expect(mockDetectFieldsOffline).not.toHaveBeenCalled();
+  });
+
+  it('should use offline detection when offline', async () => {
+    mockIsOnline.mockResolvedValue(false);
+    mockDetectFieldsOffline.mockReturnValue({
+      fields: offlineFields,
+      isOffline: true,
+      reducedAccuracy: true,
+    });
+
+    const result = await detectFields(config, pages);
+
+    expect(result.method).toBe('offline');
+    expect(result.reducedAccuracy).toBe(true);
+    expect(result.fields).toHaveLength(1);
+    expect(mockAnalyzeDocument).not.toHaveBeenCalled();
+    expect(mockDetectFieldsOffline).toHaveBeenCalledOnce();
+  });
+
+  it('should fall back to offline when cloud API fails', async () => {
+    mockIsOnline.mockResolvedValue(true);
+    mockAnalyzeDocument.mockRejectedValue(new Error('API timeout'));
+    mockDetectFieldsOffline.mockReturnValue({
+      fields: offlineFields,
+      isOffline: true,
+      reducedAccuracy: true,
+    });
+
+    const result = await detectFields(config, pages);
+
+    expect(result.method).toBe('offline');
+    expect(result.reducedAccuracy).toBe(true);
+    expect(mockAnalyzeDocument).toHaveBeenCalledOnce();
+    expect(mockDetectFieldsOffline).toHaveBeenCalledOnce();
+  });
+
+  it('should fall back to offline when network check fails', async () => {
+    mockIsOnline.mockRejectedValue(new Error('NetInfo error'));
+    mockDetectFieldsOffline.mockReturnValue({
+      fields: [],
+      isOffline: true,
+      reducedAccuracy: true,
+    });
+
+    const result = await detectFields(config, pages);
+
+    expect(result.method).toBe('offline');
+    expect(result.reducedAccuracy).toBe(true);
+  });
+
+  it('should indicate cached result from cloud', async () => {
+    mockIsOnline.mockResolvedValue(true);
+    mockAnalyzeDocument.mockResolvedValue({
+      success: true,
+      data: { fields: cloudFields },
+      meta: { cached: true, fingerprint: 'abc123', boxCount: 5 },
+    });
+
+    const result = await detectFields(config, pages);
+
+    expect(result.cached).toBe(true);
+    expect(result.method).toBe('cloud');
+  });
+
+  it('should respect forceMethod override', async () => {
+    mockDetectFieldsOffline.mockReturnValue({
+      fields: offlineFields,
+      isOffline: true,
+      reducedAccuracy: true,
+    });
+
+    const result = await detectFields({ ...config, forceMethod: 'offline' }, pages);
+
+    expect(result.method).toBe('offline');
+    expect(mockIsOnline).not.toHaveBeenCalled();
+    expect(mockAnalyzeDocument).not.toHaveBeenCalled();
+  });
+
+  it('should force cloud method when specified', async () => {
+    mockAnalyzeDocument.mockResolvedValue({
+      success: true,
+      data: { fields: cloudFields },
+      meta: { cached: false, fingerprint: 'xyz', boxCount: 1 },
+    });
+
+    const result = await detectFields({ ...config, forceMethod: 'cloud' }, pages);
+
+    expect(result.method).toBe('cloud');
+    expect(mockIsOnline).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/services/ai/aiRouter.ts
+++ b/apps/mobile/src/services/ai/aiRouter.ts
@@ -1,0 +1,153 @@
+/**
+ * Network-aware AI routing service.
+ *
+ * Routes document analysis to the cloud API when online or to
+ * local heuristic matching when offline. Provides a unified
+ * interface regardless of the detection method used.
+ */
+
+import type { DetectedFieldType } from '@fillit/shared';
+import { ApiClient } from '../api/client.js';
+import { analyzeDocument, type AnalyzeRequestInput } from '../api/analyzeService.js';
+import { isOnline } from './networkStatus.js';
+import { detectFieldsOffline, type OcrBlock } from './offlineDetection.js';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export type DetectionMethod = 'cloud' | 'offline';
+
+export interface DetectedFieldResult {
+  id: string;
+  pageNumber: number;
+  label: string;
+  fieldType: DetectedFieldType;
+  bounds: { x: number; y: number; width: number; height: number };
+  matchedField: string | null;
+  matchConfidence: number;
+}
+
+export interface DetectionResult {
+  fields: DetectedFieldResult[];
+  method: DetectionMethod;
+  /** Whether accuracy is reduced (offline mode). */
+  reducedAccuracy: boolean;
+  /** Document fingerprint (cloud only). */
+  fingerprint?: string;
+  /** Whether the result was served from cache (cloud only). */
+  cached?: boolean;
+}
+
+export interface AiRouterConfig {
+  /** API client for cloud requests. */
+  client: ApiClient;
+  /** Available profile field names for matching. */
+  availableFields: string[];
+  /** Force a specific method (for testing). */
+  forceMethod?: DetectionMethod;
+}
+
+// ─── Service ───────────────────────────────────────────────────────
+
+/**
+ * Analyze document pages using the best available method.
+ *
+ * 1. Checks network connectivity
+ * 2. If online → calls cloud API (Claude + fingerprint cache)
+ * 3. If offline → runs local heuristic matching (fuzzy + dictionary)
+ * 4. Returns unified result with method indicator
+ *
+ * The caller can show a reduced-accuracy indicator when offline
+ * results are returned.
+ */
+export async function detectFields(
+  config: AiRouterConfig,
+  pages: Array<{
+    pageNumber: number;
+    imageBase64: string;
+    ocrBlocks: OcrBlock[];
+  }>,
+): Promise<DetectionResult> {
+  const method = config.forceMethod ?? (await chooseMethod());
+
+  if (method === 'cloud') {
+    return detectViaCloud(config, pages);
+  }
+
+  return detectLocally(pages);
+}
+
+// ─── Private ───────────────────────────────────────────────────────
+
+async function chooseMethod(): Promise<DetectionMethod> {
+  try {
+    const online = await isOnline();
+    return online ? 'cloud' : 'offline';
+  } catch {
+    // Network check failed — assume offline
+    return 'offline';
+  }
+}
+
+async function detectViaCloud(
+  config: AiRouterConfig,
+  pages: Array<{
+    pageNumber: number;
+    imageBase64: string;
+    ocrBlocks: OcrBlock[];
+  }>,
+): Promise<DetectionResult> {
+  try {
+    const input: AnalyzeRequestInput = {
+      pages: pages.map((p) => ({
+        pageNumber: p.pageNumber,
+        imageBase64: p.imageBase64,
+        ocrBlocks: p.ocrBlocks,
+      })),
+      availableFields: config.availableFields,
+    };
+
+    const response = await analyzeDocument(config.client, input);
+
+    return {
+      fields: response.data.fields.map((f) => ({
+        id: f.id,
+        pageNumber: f.pageNumber,
+        label: f.label,
+        fieldType: f.fieldType,
+        bounds: f.bounds,
+        matchedField: f.matchedField,
+        matchConfidence: f.matchConfidence,
+      })),
+      method: 'cloud',
+      reducedAccuracy: false,
+      fingerprint: response.meta.fingerprint,
+      cached: response.meta.cached,
+    };
+  } catch {
+    // Cloud failed — fall back to offline
+    return detectLocally(pages);
+  }
+}
+
+function detectLocally(
+  pages: Array<{
+    pageNumber: number;
+    ocrBlocks: OcrBlock[];
+  }>,
+): DetectionResult {
+  const result = detectFieldsOffline(pages);
+
+  return {
+    fields: result.fields.map((f) => ({
+      id: f.id,
+      pageNumber: f.pageNumber,
+      label: f.label,
+      fieldType: f.fieldType,
+      bounds: f.bounds,
+      matchedField: f.matchedField,
+      matchConfidence: f.matchConfidence,
+    })),
+    method: 'offline',
+    reducedAccuracy: true,
+  };
+}

--- a/apps/mobile/src/services/ai/index.ts
+++ b/apps/mobile/src/services/ai/index.ts
@@ -1,0 +1,11 @@
+export { detectFields } from './aiRouter.js';
+export type {
+  AiRouterConfig,
+  DetectedFieldResult,
+  DetectionMethod,
+  DetectionResult,
+} from './aiRouter.js';
+export { isOnline, getNetworkState } from './networkStatus.js';
+export type { NetworkState } from './networkStatus.js';
+export { detectFieldsOffline } from './offlineDetection.js';
+export type { OfflineDetectedField, OfflineDetectionResult } from './offlineDetection.js';

--- a/apps/mobile/src/services/ai/networkStatus.ts
+++ b/apps/mobile/src/services/ai/networkStatus.ts
@@ -1,0 +1,38 @@
+/**
+ * Network status detection for AI routing decisions.
+ *
+ * Wraps @react-native-community/netinfo to provide a simple
+ * online/offline check for the AI routing service.
+ */
+
+import NetInfo from '@react-native-community/netinfo';
+
+export interface NetworkState {
+  isConnected: boolean;
+  isInternetReachable: boolean;
+}
+
+/**
+ * Check current network connectivity.
+ *
+ * Returns both connection status and internet reachability.
+ * A device can be connected to WiFi without internet access,
+ * so both checks matter for API-dependent features.
+ */
+export async function getNetworkState(): Promise<NetworkState> {
+  const state = await NetInfo.fetch();
+  return {
+    isConnected: state.isConnected ?? false,
+    isInternetReachable: state.isInternetReachable ?? false,
+  };
+}
+
+/**
+ * Check if the device can reach the internet.
+ *
+ * Convenience wrapper that checks both connection and reachability.
+ */
+export async function isOnline(): Promise<boolean> {
+  const state = await getNetworkState();
+  return state.isConnected && state.isInternetReachable;
+}

--- a/apps/mobile/src/services/ai/offlineDetection.ts
+++ b/apps/mobile/src/services/ai/offlineDetection.ts
@@ -1,0 +1,83 @@
+/**
+ * Offline field detection using local heuristics.
+ *
+ * Fallback when the device is offline or the API is unreachable.
+ * Uses the label dictionary + fuzzy matching from @fillit/shared
+ * to detect fields without Claude API calls.
+ */
+
+import { findBestMatch, type MatchResult } from '@fillit/shared';
+import type { DetectedFieldType } from '@fillit/shared';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface OcrBlock {
+  text: string;
+  bounds: { x: number; y: number; width: number; height: number };
+  confidence: number;
+}
+
+export interface OfflineDetectedField {
+  id: string;
+  pageNumber: number;
+  label: string;
+  fieldType: DetectedFieldType;
+  bounds: { x: number; y: number; width: number; height: number };
+  matchedField: string | null;
+  matchConfidence: number;
+  matchMethod: 'exact' | 'fuzzy' | 'none';
+}
+
+export interface OfflineDetectionResult {
+  fields: OfflineDetectedField[];
+  isOffline: true;
+  reducedAccuracy: true;
+}
+
+// ─── Service ───────────────────────────────────────────────────────
+
+/**
+ * Run offline field detection on OCR blocks using local heuristics.
+ *
+ * For each OCR block, attempts to match the text against the label
+ * dictionary (exact match) and falls back to fuzzy matching. Returns
+ * detected fields with confidence scores.
+ *
+ * Accuracy is lower than Claude API — the result includes flags
+ * to indicate this to the UI.
+ */
+export function detectFieldsOffline(
+  pages: Array<{ pageNumber: number; ocrBlocks: OcrBlock[] }>,
+): OfflineDetectionResult {
+  const fields: OfflineDetectedField[] = [];
+  let fieldIndex = 0;
+
+  for (const page of pages) {
+    for (const block of page.ocrBlocks) {
+      // Skip low-confidence OCR blocks
+      if (block.confidence < 0.5) continue;
+
+      const match: MatchResult = findBestMatch(block.text);
+
+      // Only include blocks that matched something
+      if (match.matchMethod !== 'none') {
+        fields.push({
+          id: `offline-field-${fieldIndex++}`,
+          pageNumber: page.pageNumber,
+          label: block.text,
+          fieldType: match.fieldType,
+          bounds: block.bounds,
+          matchedField: match.fieldPath || null,
+          matchConfidence: match.confidence,
+          matchMethod: match.matchMethod,
+        });
+      }
+    }
+  }
+
+  return {
+    fields,
+    isOffline: true,
+    reducedAccuracy: true,
+  };
+}


### PR DESCRIPTION
## Summary
- **AI Router** — routes document analysis to cloud API (online) or local heuristics (offline)
- **Network Status** — wraps @react-native-community/netinfo for connectivity checks
- **Offline Detection** — uses label dictionary + fuzzy matching from @fillit/shared
- Automatic fallback to offline when cloud API fails or network is unreachable
- `forceMethod` option for testing specific paths
- `reducedAccuracy` flag so UI can indicate offline mode to users

Closes #64

## How It Works
```
detectFields(config, pages)
  → isOnline()?
    → YES: analyzeDocument() via cloud API
      → API fails? → fallback to offline
    → NO: detectFieldsOffline() via local heuristics
  → Return unified DetectionResult { fields, method, reducedAccuracy }
```

## Acceptance Criteria
- [x] Network status detection
- [x] Route to Claude API when online
- [x] Fall back to local fuzzy matching when offline
- [x] Indicate reduced accuracy in offline mode

## Test Plan
- [x] 7 tests (cloud routing, offline routing, cloud fallback, network check failure, cache indicator, forceMethod)
- [x] TypeScript clean, Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)