### PR TITLE
feat(mobile): add field matching/review screen (S-67)

### DIFF
--- a/apps/mobile/src/components/detection/FieldReviewScreen.tsx
+++ b/apps/mobile/src/components/detection/FieldReviewScreen.tsx
@@ -1,0 +1,288 @@
+/**
+ * Field matching and review screen.
+ *
+ * Displays the document with field overlays, a field list with
+ * matched values, and the field editor bottom sheet. Users can
+ * review, edit, or skip each detected field before confirming
+ * all fields and proceeding to signatures/export.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { FlatList, StyleSheet, Text, View } from 'react-native';
+import type { DetectedField } from '@fillit/shared';
+
+import { useTheme } from '../../theme';
+import { Button } from '../ui/Button';
+import { Chip } from '../ui/Badge';
+import { DocumentViewer } from '../document/DocumentViewer';
+import { FieldEditorSheet, type FieldEditResult } from '../document/FieldEditorSheet';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface FieldReviewScreenProps {
+  /** Document page image URI. */
+  imageUri: string;
+  /** Original image dimensions. */
+  imageWidth: number;
+  imageHeight: number;
+  /** Detected fields to review. */
+  fields: DetectedField[];
+  /** Called when a field is updated. */
+  onFieldUpdate: (result: FieldEditResult) => void;
+  /** Called when the user confirms all fields. */
+  onConfirmAll: () => void;
+  /** Called when the user wants to re-analyze. */
+  onReAnalyze: () => void;
+  /** Whether the detection used reduced accuracy (offline). */
+  reducedAccuracy?: boolean;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function getFieldStatusColor(field: DetectedField): 'success' | 'warning' | 'error' | 'default' {
+  if (field.isConfirmed) return 'success';
+  if (field.matchConfidence >= 0.7) return 'success';
+  if (field.matchConfidence >= 0.4) return 'warning';
+  if (field.matchConfidence > 0) return 'error';
+  return 'default';
+}
+
+function getFieldStatusLabel(field: DetectedField): string {
+  if (field.isConfirmed) return 'Confirmed';
+  if (field.matchConfidence >= 0.7) return `${Math.round(field.matchConfidence * 100)}%`;
+  if (field.matchConfidence >= 0.4) return `${Math.round(field.matchConfidence * 100)}%`;
+  if (field.matchConfidence > 0) return `${Math.round(field.matchConfidence * 100)}%`;
+  return 'No match';
+}
+
+// ─── Component ─────────────────────────────────────────────────────
+
+export function FieldReviewScreen({
+  imageUri,
+  imageWidth,
+  imageHeight,
+  fields,
+  onFieldUpdate,
+  onConfirmAll,
+  onReAnalyze,
+  reducedAccuracy = false,
+}: FieldReviewScreenProps) {
+  const { theme } = useTheme();
+  const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
+
+  const selectedField = useMemo(
+    () => fields.find((f) => f.id === selectedFieldId) ?? null,
+    [fields, selectedFieldId],
+  );
+
+  const confirmedCount = useMemo(() => fields.filter((f) => f.isConfirmed).length, [fields]);
+
+  const allConfirmed = confirmedCount === fields.length && fields.length > 0;
+
+  const handleFieldPress = useCallback((field: DetectedField) => {
+    setSelectedFieldId(field.id);
+  }, []);
+
+  const handleEditorSave = useCallback(
+    (result: FieldEditResult) => {
+      onFieldUpdate(result);
+      // Auto-advance to next unconfirmed field
+      const currentIndex = fields.findIndex((f) => f.id === result.fieldId);
+      const nextUnconfirmed = fields.find((f, i) => i > currentIndex && !f.isConfirmed);
+      setSelectedFieldId(nextUnconfirmed?.id ?? null);
+    },
+    [fields, onFieldUpdate],
+  );
+
+  const handleEditorDismiss = useCallback(() => {
+    setSelectedFieldId(null);
+  }, []);
+
+  const renderFieldItem = useCallback(
+    ({ item }: { item: DetectedField }) => (
+      <View
+        style={[
+          styles.fieldItem,
+          {
+            backgroundColor: theme.colors.surface,
+            borderRadius: theme.radii.md,
+            padding: theme.spacing.md,
+            marginBottom: theme.spacing.sm,
+            borderLeftWidth: 3,
+            borderLeftColor: item.isConfirmed
+              ? theme.colors.success
+              : item.matchConfidence >= 0.7
+                ? theme.colors.success
+                : item.matchConfidence >= 0.4
+                  ? theme.colors.warning
+                  : theme.colors.error,
+          },
+        ]}
+        testID={`field-review-item-${item.id}`}
+      >
+        <View style={styles.fieldItemHeader}>
+          <Text
+            style={[theme.typography.bodyMedium, { color: theme.colors.onSurface, flex: 1 }]}
+            numberOfLines={1}
+          >
+            {item.label}
+          </Text>
+          <Chip
+            label={getFieldStatusLabel(item)}
+            color={getFieldStatusColor(item)}
+            variant="filled"
+          />
+        </View>
+        <Text
+          style={[
+            theme.typography.bodySmall,
+            {
+              color: item.value ? theme.colors.onSurface : theme.colors.onSurfaceVariant,
+              marginTop: theme.spacing.xs,
+            },
+          ]}
+          numberOfLines={1}
+        >
+          {item.value || 'No value'}
+        </Text>
+        <Button
+          label="Edit"
+          variant="ghost"
+          size="sm"
+          onPress={() => handleFieldPress(item)}
+          style={{ alignSelf: 'flex-end', marginTop: theme.spacing.xs }}
+          testID={`field-review-edit-${item.id}`}
+        />
+      </View>
+    ),
+    [theme, handleFieldPress],
+  );
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      testID="field-review-screen"
+    >
+      {/* Reduced accuracy warning */}
+      {reducedAccuracy ? (
+        <View
+          style={[
+            styles.warningBar,
+            {
+              backgroundColor: theme.colors.warningLight,
+              paddingVertical: theme.spacing.sm,
+              paddingHorizontal: theme.spacing.lg,
+            },
+          ]}
+          accessibilityRole="alert"
+        >
+          <Text style={[theme.typography.labelMedium, { color: theme.colors.warning }]}>
+            Offline detection — review fields carefully
+          </Text>
+        </View>
+      ) : null}
+
+      {/* Document viewer with overlays */}
+      <View style={styles.viewerSection}>
+        <DocumentViewer
+          imageUri={imageUri}
+          imageWidth={imageWidth}
+          imageHeight={imageHeight}
+          fields={fields}
+          selectedFieldId={selectedFieldId ?? undefined}
+          onFieldPress={handleFieldPress}
+        />
+      </View>
+
+      {/* Progress indicator */}
+      <View
+        style={[
+          styles.progressBar,
+          { paddingHorizontal: theme.spacing.lg, paddingVertical: theme.spacing.sm },
+        ]}
+      >
+        <Text style={[theme.typography.labelMedium, { color: theme.colors.onSurfaceVariant }]}>
+          {confirmedCount}/{fields.length} fields confirmed
+        </Text>
+      </View>
+
+      {/* Field list */}
+      <FlatList
+        data={fields}
+        renderItem={renderFieldItem}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={{ padding: theme.spacing.lg }}
+        style={styles.fieldList}
+        testID="field-review-list"
+      />
+
+      {/* Actions */}
+      <View
+        style={[
+          styles.actions,
+          {
+            padding: theme.spacing.lg,
+            backgroundColor: theme.colors.surface,
+            ...theme.elevations.md,
+          },
+        ]}
+      >
+        <Button
+          label="Re-analyze"
+          variant="outline"
+          size="md"
+          onPress={onReAnalyze}
+          testID="field-review-reanalyze"
+          style={{ marginRight: theme.spacing.sm }}
+        />
+        <Button
+          label={allConfirmed ? 'Proceed' : `Confirm All (${confirmedCount}/${fields.length})`}
+          variant="primary"
+          size="md"
+          onPress={onConfirmAll}
+          testID="field-review-confirm"
+          style={{ flex: 1 }}
+        />
+      </View>
+
+      {/* Field editor bottom sheet */}
+      <FieldEditorSheet
+        field={selectedField}
+        onSave={handleEditorSave}
+        onDismiss={handleEditorDismiss}
+      />
+    </View>
+  );
+}
+
+// ─── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  warningBar: {
+    alignItems: 'center',
+  },
+  viewerSection: {
+    height: 250,
+  },
+  progressBar: {
+    alignItems: 'center',
+  },
+  fieldList: {
+    flex: 1,
+  },
+  fieldItem: {},
+  fieldItemHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+
+FieldReviewScreen.displayName = 'FieldReviewScreen';

--- a/apps/mobile/src/components/detection/__tests__/FieldDetectionProgress.test.ts
+++ b/apps/mobile/src/components/detection/__tests__/FieldDetectionProgress.test.ts
@@ -6,10 +6,13 @@ import type { UseFieldDetectionReturn } from '../../../hooks/useFieldDetection';
 
 vi.mock('react-native', () => ({
   ActivityIndicator: 'ActivityIndicator',
+  FlatList: 'FlatList',
+  Keyboard: { dismiss: vi.fn() },
   Pressable: 'Pressable',
   StyleSheet: {
     create: (s: Record<string, unknown>) => s,
     flatten: (s: unknown) => s,
+    absoluteFill: {},
   },
   Text: 'Text',
   View: 'View',
@@ -17,6 +20,31 @@ vi.mock('react-native', () => ({
 
 vi.mock('@expo/vector-icons', () => ({
   Ionicons: 'Ionicons',
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: 'Animated.View' },
+  useAnimatedStyle: vi.fn((fn: () => unknown) => fn()),
+  useSharedValue: vi.fn((v: number) => ({ value: v })),
+  withTiming: vi.fn((v: number) => v),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: vi.fn(() => ({ top: 0, right: 0, bottom: 0, left: 0 })),
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  GestureDetector: 'GestureDetector',
+  GestureHandlerRootView: 'GestureHandlerRootView',
+  Gesture: {
+    Pinch: vi.fn(() => ({ onUpdate: vi.fn().mockReturnThis(), onEnd: vi.fn().mockReturnThis() })),
+    Pan: vi.fn(() => ({ onUpdate: vi.fn().mockReturnThis(), onEnd: vi.fn().mockReturnThis() })),
+    Tap: vi.fn(() => ({
+      numberOfTaps: vi.fn().mockReturnThis(),
+      onEnd: vi.fn().mockReturnThis(),
+    })),
+    Simultaneous: vi.fn(),
+  },
 }));
 
 vi.mock('../../../theme', async () => {

--- a/apps/mobile/src/components/detection/__tests__/FieldReviewScreen.test.ts
+++ b/apps/mobile/src/components/detection/__tests__/FieldReviewScreen.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type * as FieldReviewScreenModule from '../FieldReviewScreen';
+import type { FieldReviewScreenProps } from '../FieldReviewScreen';
+import type { DetectedField } from '@fillit/shared';
+
+// ─── Mocks ─────────────────────────────────────────────────────────
+
+vi.mock('react-native', () => ({
+  FlatList: 'FlatList',
+  Pressable: 'Pressable',
+  StyleSheet: {
+    create: (s: Record<string, unknown>) => s,
+    flatten: (s: unknown) => s,
+    absoluteFill: {},
+  },
+  Text: 'Text',
+  View: 'View',
+  Keyboard: { dismiss: vi.fn() },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: 'Animated.View' },
+  useAnimatedStyle: vi.fn((fn: () => unknown) => fn()),
+  useSharedValue: vi.fn((v: number) => ({ value: v })),
+  withTiming: vi.fn((v: number) => v),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: vi.fn(() => ({ top: 0, right: 0, bottom: 0, left: 0 })),
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  GestureDetector: 'GestureDetector',
+  GestureHandlerRootView: 'GestureHandlerRootView',
+  Gesture: {
+    Pinch: vi.fn(() => ({ onUpdate: vi.fn().mockReturnThis(), onEnd: vi.fn().mockReturnThis() })),
+    Pan: vi.fn(() => ({ onUpdate: vi.fn().mockReturnThis(), onEnd: vi.fn().mockReturnThis() })),
+    Tap: vi.fn(() => ({
+      numberOfTaps: vi.fn().mockReturnThis(),
+      onEnd: vi.fn().mockReturnThis(),
+    })),
+    Simultaneous: vi.fn(),
+  },
+}));
+
+vi.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+vi.mock('../../../theme', async () => {
+  const { lightTheme } = await import('../../../theme/themes');
+  return {
+    useTheme: () => ({
+      theme: lightTheme,
+      isDark: false,
+      colorMode: 'system' as const,
+      resolvedColorScheme: 'light' as const,
+      setColorMode: () => {},
+      toggleColorMode: () => {},
+    }),
+  };
+});
+
+// ─── Test Data ─────────────────────────────────────────────────────
+
+function makeField(overrides?: Partial<DetectedField>): DetectedField {
+  return {
+    id: 'field-1',
+    pageId: 'page-1',
+    label: 'First Name',
+    normalizedLabel: 'first name',
+    fieldType: 'text',
+    bounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.04 },
+    matchedProfileField: 'firstName',
+    matchConfidence: 0.9,
+    value: 'John',
+    isConfirmed: false,
+    isSignatureField: false,
+    ...overrides,
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe('FieldReviewScreen', () => {
+  let mod: typeof FieldReviewScreenModule;
+
+  beforeAll(async () => {
+    mod = await import('../FieldReviewScreen');
+  });
+
+  describe('module exports', () => {
+    it('should export the FieldReviewScreen component', () => {
+      expect(mod.FieldReviewScreen).toBeDefined();
+      expect(typeof mod.FieldReviewScreen).toBe('function');
+    });
+
+    it('should have displayName set', () => {
+      expect(mod.FieldReviewScreen.displayName).toBe('FieldReviewScreen');
+    });
+  });
+
+  describe('props type', () => {
+    it('should satisfy the props interface', () => {
+      const props: FieldReviewScreenProps = {
+        imageUri: 'file:///test.jpg',
+        imageWidth: 1080,
+        imageHeight: 1920,
+        fields: [makeField(), makeField({ id: 'field-2', label: 'Last Name' })],
+        onFieldUpdate: vi.fn(),
+        onConfirmAll: vi.fn(),
+        onReAnalyze: vi.fn(),
+        reducedAccuracy: false,
+      };
+      expect(props.fields).toHaveLength(2);
+      expect(props.imageUri).toBeTruthy();
+    });
+
+    it('should support reduced accuracy mode', () => {
+      const props: FieldReviewScreenProps = {
+        imageUri: 'file:///test.jpg',
+        imageWidth: 1080,
+        imageHeight: 1920,
+        fields: [makeField({ matchConfidence: 0.6, isConfirmed: false })],
+        onFieldUpdate: vi.fn(),
+        onConfirmAll: vi.fn(),
+        onReAnalyze: vi.fn(),
+        reducedAccuracy: true,
+      };
+      expect(props.reducedAccuracy).toBe(true);
+    });
+
+    it('should handle confirmed fields', () => {
+      const fields = [
+        makeField({ id: 'f1', isConfirmed: true }),
+        makeField({ id: 'f2', isConfirmed: false }),
+        makeField({ id: 'f3', isConfirmed: true }),
+      ];
+      const confirmed = fields.filter((f) => f.isConfirmed);
+      expect(confirmed).toHaveLength(2);
+    });
+
+    it('should handle empty fields array', () => {
+      const props: FieldReviewScreenProps = {
+        imageUri: 'file:///test.jpg',
+        imageWidth: 1080,
+        imageHeight: 1920,
+        fields: [],
+        onFieldUpdate: vi.fn(),
+        onConfirmAll: vi.fn(),
+        onReAnalyze: vi.fn(),
+      };
+      expect(props.fields).toHaveLength(0);
+    });
+  });
+});
+
+describe('detection barrel export', () => {
+  it('should re-export FieldReviewScreen from index', async () => {
+    const index = await import('../index');
+    expect(index.FieldReviewScreen).toBeDefined();
+    expect(typeof index.FieldReviewScreen).toBe('function');
+  });
+});

--- a/apps/mobile/src/components/detection/index.ts
+++ b/apps/mobile/src/components/detection/index.ts
@@ -1,2 +1,4 @@
 export { FieldDetectionProgress } from './FieldDetectionProgress';
 export type { FieldDetectionProgressProps } from './FieldDetectionProgress';
+export { FieldReviewScreen } from './FieldReviewScreen';
+export type { FieldReviewScreenProps } from './FieldReviewScreen';


### PR DESCRIPTION
## Summary
- **FieldReviewScreen** — the final piece of the AI detection pipeline. Combines DocumentViewer, FieldEditorSheet, and a scrollable field list into a unified review experience
- Users can review all detected fields, edit values, change sources, and confirm before proceeding to signatures

Closes #68

## Features
- Document viewer with zoomable image and color-coded field overlays
- Scrollable field list with confidence indicators (green/yellow/red borders)
- Tap field → editor bottom sheet opens
- Auto-advance to next unconfirmed field after save
- Progress counter (X/Y fields confirmed)
- Reduced accuracy warning for offline detection
- Re-analyze button to retry with cloud API
- Confirm All / Proceed button

## Acceptance Criteria
- [x] List of all detected fields with values
- [x] Document viewer with overlays
- [x] Edit via bottom sheet
- [x] Confirm all and proceed to signatures
- [x] Back to re-analyze

## Test Plan
- [x] 13 tests passing (exports, props types, barrel exports)
- [x] TypeScript clean, Prettier formatted

## End-to-End AI Detection — Complete!
This story completes the full AI field detection chain:
```
Scan → OCR → Image optimization → AI routing (cloud/offline)
→ Field detection → Progress screen → Field review/edit → Confirm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)