### PR TITLE
feat(mobile): add signature management screen (S-71)

### DIFF
--- a/apps/mobile/app/(tabs)/profiles.tsx
+++ b/apps/mobile/app/(tabs)/profiles.tsx
@@ -211,6 +211,15 @@ function ManagementButtons() {
         style={{ marginTop: theme.spacing.sm }}
         testID="manage-emergency-button"
       />
+      <Button
+        label="Signatures"
+        variant="outline"
+        onPress={() => router.push('/profile/signature' as never)}
+        fullWidth
+        iconLeft={<Ionicons name="create-outline" size={18} color={theme.colors.primary} />}
+        style={{ marginTop: theme.spacing.sm }}
+        testID="manage-signatures-button"
+      />
     </View>
   );
 }

--- a/apps/mobile/app/profile/signature/add.tsx
+++ b/apps/mobile/app/profile/signature/add.tsx
@@ -1,0 +1,223 @@
+/**
+ * Add signature screen.
+ *
+ * Lets the user create a new drawn or typed signature. The user can
+ * toggle between modes, enter a label, and save to the active profile.
+ */
+
+import { useCallback, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { router } from 'expo-router';
+import * as Crypto from 'expo-crypto';
+
+import { useTheme } from '../../../src/theme';
+import { ScreenHeader } from '../../../src/components/profile/ScreenHeader';
+import {
+  SignaturePad,
+  TypedSignature,
+  type SignaturePadResult,
+  type TypedSignatureResult,
+} from '../../../src/components/signature';
+import { TextInput } from '../../../src/components/ui/TextInput';
+import { Chip } from '../../../src/components/ui/Badge';
+import { Button } from '../../../src/components/ui/Button';
+import {
+  useProfileStore,
+  selectActiveProfile,
+  selectActiveProfileSignatures,
+} from '../../../src/stores/profile-store';
+
+type SignatureMode = 'drawn' | 'typed';
+
+export default function AddSignatureScreen() {
+  const { theme } = useTheme();
+  const profile = useProfileStore(selectActiveProfile);
+  const signatures = useProfileStore(selectActiveProfileSignatures);
+  const createSignature = useProfileStore((s) => s.createSignature);
+
+  const [mode, setMode] = useState<SignatureMode>('drawn');
+  const [label, setLabel] = useState('');
+  const [drawnResult, setDrawnResult] = useState<SignaturePadResult | null>(null);
+  const [typedResult, setTypedResult] = useState<TypedSignatureResult | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const isFirstSignature = signatures.length === 0;
+  const hasSignature = mode === 'drawn' ? drawnResult !== null : typedResult !== null;
+  const hasLabel = label.trim().length > 0;
+  const canSave = hasSignature && hasLabel && !isSaving;
+
+  const handleDrawnSave = useCallback((result: SignaturePadResult) => {
+    setDrawnResult(result);
+  }, []);
+
+  const handleTypedSave = useCallback((result: TypedSignatureResult) => {
+    setTypedResult(result);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!profile || !canSave) return;
+
+    setIsSaving(true);
+    try {
+      const id = Crypto.randomUUID();
+      if (mode === 'drawn' && drawnResult) {
+        await createSignature({
+          id,
+          profileId: profile.id,
+          type: 'drawn',
+          label: label.trim(),
+          svgPath: drawnResult.svgPath,
+          isDefault: isFirstSignature,
+        });
+      } else if (mode === 'typed' && typedResult) {
+        await createSignature({
+          id,
+          profileId: profile.id,
+          type: 'typed',
+          label: label.trim(),
+          text: typedResult.text,
+          fontFamily: typedResult.fontFamily,
+          isDefault: isFirstSignature,
+        });
+      }
+      router.back();
+    } catch (err) {
+      Alert.alert('Error', err instanceof Error ? err.message : 'Failed to save signature.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [profile, canSave, mode, drawnResult, typedResult, label, isFirstSignature, createSignature]);
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      testID="add-signature-screen"
+    >
+      <ScreenHeader title="Add Signature" onBack={() => router.back()} />
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={{ padding: theme.spacing.lg }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Label input */}
+          <TextInput
+            label="Signature label"
+            value={label}
+            onChangeText={setLabel}
+            placeholder='e.g. "Full name", "Initials"'
+            variant="outlined"
+            maxLength={50}
+            testID="signature-label-input"
+          />
+
+          {/* Mode tabs */}
+          <View style={[styles.modeRow, { marginTop: theme.spacing.lg }]}>
+            <Text
+              style={[
+                theme.typography.labelMedium,
+                {
+                  color: theme.colors.onSurfaceVariant,
+                  marginBottom: theme.spacing.sm,
+                },
+              ]}
+            >
+              Signature type
+            </Text>
+            <View style={styles.modeChips}>
+              <Chip
+                label="Draw"
+                variant={mode === 'drawn' ? 'filled' : 'outlined'}
+                color={mode === 'drawn' ? 'primary' : 'default'}
+                selected={mode === 'drawn'}
+                onPress={() => setMode('drawn')}
+                style={{ marginRight: theme.spacing.sm }}
+              />
+              <Chip
+                label="Type"
+                variant={mode === 'typed' ? 'filled' : 'outlined'}
+                color={mode === 'typed' ? 'primary' : 'default'}
+                selected={mode === 'typed'}
+                onPress={() => setMode('typed')}
+              />
+            </View>
+          </View>
+
+          {/* Signature input */}
+          <View style={{ marginTop: theme.spacing.lg }}>
+            {mode === 'drawn' ? (
+              <View>
+                <SignaturePad onSave={handleDrawnSave} height={200} />
+                {drawnResult ? (
+                  <Text
+                    style={[
+                      theme.typography.bodySmall,
+                      {
+                        color: theme.colors.primary,
+                        marginTop: theme.spacing.sm,
+                        textAlign: 'center',
+                      },
+                    ]}
+                  >
+                    Signature captured
+                  </Text>
+                ) : null}
+              </View>
+            ) : (
+              <TypedSignature onSave={handleTypedSave} />
+            )}
+          </View>
+
+          {/* Save button */}
+          <Button
+            label={isSaving ? 'Saving...' : 'Save Signature'}
+            variant="primary"
+            size="lg"
+            onPress={handleSave}
+            disabled={!canSave}
+            testID="save-signature-button"
+            style={{ marginTop: theme.spacing.xl }}
+          />
+
+          {isFirstSignature ? (
+            <Text
+              style={[
+                theme.typography.bodySmall,
+                {
+                  color: theme.colors.onSurfaceVariant,
+                  textAlign: 'center',
+                  marginTop: theme.spacing.sm,
+                },
+              ]}
+            >
+              This will be set as your default signature.
+            </Text>
+          ) : null}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  flex: {
+    flex: 1,
+  },
+  modeRow: {},
+  modeChips: {
+    flexDirection: 'row',
+  },
+});

--- a/apps/mobile/app/profile/signature/index.tsx
+++ b/apps/mobile/app/profile/signature/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * Signature management screen.
+ *
+ * Lists all saved signatures for the active profile. Supports
+ * adding new signatures, deleting existing ones, and setting a default.
+ */
+
+import { useCallback } from 'react';
+import { View, StyleSheet, Alert } from 'react-native';
+import { router } from 'expo-router';
+
+import { useTheme } from '../../../src/theme';
+import { ScreenHeader } from '../../../src/components/profile/ScreenHeader';
+import { SignatureList } from '../../../src/components/signature';
+import {
+  useProfileStore,
+  selectActiveProfile,
+  selectActiveProfileSignatures,
+} from '../../../src/stores/profile-store';
+
+export default function SignatureManagementScreen() {
+  const { theme } = useTheme();
+  const profile = useProfileStore(selectActiveProfile);
+  const signatures = useProfileStore(selectActiveProfileSignatures);
+  const deleteSignature = useProfileStore((s) => s.deleteSignature);
+  const setDefaultSignature = useProfileStore((s) => s.setDefaultSignature);
+
+  const handleAdd = useCallback(() => {
+    router.push('/profile/signature/add' as never);
+  }, []);
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      if (!profile) return;
+      try {
+        await deleteSignature(id, profile.id);
+      } catch (err) {
+        Alert.alert('Error', err instanceof Error ? err.message : 'Failed to delete signature.');
+      }
+    },
+    [profile, deleteSignature],
+  );
+
+  const handleSetDefault = useCallback(
+    async (id: string) => {
+      if (!profile) return;
+      try {
+        await setDefaultSignature(id, profile.id);
+      } catch (err) {
+        Alert.alert(
+          'Error',
+          err instanceof Error ? err.message : 'Failed to set default signature.',
+        );
+      }
+    },
+    [profile, setDefaultSignature],
+  );
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      testID="signature-management-screen"
+    >
+      <ScreenHeader title="Signatures" onBack={() => router.back()} />
+      <SignatureList
+        signatures={signatures}
+        onAdd={handleAdd}
+        onDelete={handleDelete}
+        onSetDefault={handleSetDefault}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/apps/mobile/src/components/signature/SignatureList.tsx
+++ b/apps/mobile/src/components/signature/SignatureList.tsx
@@ -1,0 +1,237 @@
+/**
+ * Signature list component.
+ *
+ * Displays saved signatures with preview thumbnails. Supports
+ * setting a default, deleting, and adding new signatures.
+ */
+
+import { useCallback } from 'react';
+import { Alert, FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import type { StoredSignature } from '@fillit/shared';
+
+import { useTheme } from '../../theme';
+import { SignaturePreview } from './SignaturePreview';
+import { Button } from '../ui/Button';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface SignatureListProps {
+  /** The list of signatures to display. */
+  signatures: StoredSignature[];
+  /** Called when the user taps "Add signature". */
+  onAdd: () => void;
+  /** Called when the user deletes a signature. */
+  onDelete: (id: string) => void;
+  /** Called when the user sets a signature as default. */
+  onSetDefault: (id: string) => void;
+}
+
+// ─── Component ─────────────────────────────────────────────────────
+
+export function SignatureList({ signatures, onAdd, onDelete, onSetDefault }: SignatureListProps) {
+  const { theme } = useTheme();
+
+  const handleDelete = useCallback(
+    (sig: StoredSignature) => {
+      Alert.alert('Delete Signature', `Are you sure you want to delete "${sig.label}"?`, [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => onDelete(sig.id),
+        },
+      ]);
+    },
+    [onDelete],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: StoredSignature }) => (
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: theme.colors.surface,
+            borderColor: item.isDefault ? theme.colors.primary : theme.colors.outline,
+            borderWidth: item.isDefault ? 2 : 1,
+            borderRadius: theme.radii.md,
+            padding: theme.spacing.md,
+            marginBottom: theme.spacing.sm,
+          },
+        ]}
+        testID={`signature-card-${item.id}`}
+      >
+        {/* Header: label + default badge */}
+        <View style={styles.cardHeader}>
+          <View style={styles.labelRow}>
+            <Text
+              style={[theme.typography.labelLarge, { color: theme.colors.onSurface, flex: 1 }]}
+              numberOfLines={1}
+            >
+              {item.label}
+            </Text>
+            {item.isDefault ? (
+              <View
+                style={[
+                  styles.defaultBadge,
+                  {
+                    backgroundColor: theme.colors.primaryLight,
+                    borderRadius: theme.radii.sm,
+                    paddingHorizontal: theme.spacing.sm,
+                    paddingVertical: 2,
+                  },
+                ]}
+              >
+                <Text style={[theme.typography.labelSmall, { color: theme.colors.onPrimary }]}>
+                  Default
+                </Text>
+              </View>
+            ) : null}
+          </View>
+          <Text
+            style={[
+              theme.typography.bodySmall,
+              {
+                color: theme.colors.onSurfaceVariant,
+                marginTop: 2,
+              },
+            ]}
+          >
+            {item.type === 'drawn' ? 'Drawn' : 'Typed'} signature
+          </Text>
+        </View>
+
+        {/* Preview */}
+        <View style={{ marginTop: theme.spacing.sm }}>
+          <SignaturePreview signature={item} size="thumbnail" expandable />
+        </View>
+
+        {/* Actions */}
+        <View style={[styles.cardActions, { marginTop: theme.spacing.sm }]}>
+          {!item.isDefault ? (
+            <Pressable
+              style={[styles.actionButton, { marginRight: theme.spacing.md }]}
+              onPress={() => onSetDefault(item.id)}
+              accessibilityRole="button"
+              accessibilityLabel={`Set ${item.label} as default signature`}
+              testID={`signature-set-default-${item.id}`}
+            >
+              <Ionicons name="star-outline" size={18} color={theme.colors.primary} />
+              <Text
+                style={[
+                  theme.typography.labelMedium,
+                  { color: theme.colors.primary, marginLeft: 4 },
+                ]}
+              >
+                Set default
+              </Text>
+            </Pressable>
+          ) : null}
+          <Pressable
+            style={styles.actionButton}
+            onPress={() => handleDelete(item)}
+            accessibilityRole="button"
+            accessibilityLabel={`Delete ${item.label}`}
+            testID={`signature-delete-${item.id}`}
+          >
+            <Ionicons name="trash-outline" size={18} color={theme.colors.error} />
+            <Text
+              style={[theme.typography.labelMedium, { color: theme.colors.error, marginLeft: 4 }]}
+            >
+              Delete
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    ),
+    [theme, onSetDefault, handleDelete],
+  );
+
+  const keyExtractor = useCallback((item: StoredSignature) => item.id, []);
+
+  return (
+    <View style={styles.container} testID="signature-list">
+      <FlatList
+        data={signatures}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        contentContainerStyle={{
+          padding: theme.spacing.lg,
+          paddingBottom: theme.spacing['3xl'],
+        }}
+        ListEmptyComponent={
+          <View style={[styles.empty, { padding: theme.spacing.xl }]}>
+            <Ionicons name="create-outline" size={48} color={theme.colors.onSurfaceVariant} />
+            <Text
+              style={[
+                theme.typography.bodyLarge,
+                {
+                  color: theme.colors.onSurfaceVariant,
+                  marginTop: theme.spacing.md,
+                  textAlign: 'center',
+                },
+              ]}
+            >
+              No signatures yet
+            </Text>
+            <Text
+              style={[
+                theme.typography.bodyMedium,
+                {
+                  color: theme.colors.onSurfaceVariant,
+                  marginTop: theme.spacing.xs,
+                  textAlign: 'center',
+                },
+              ]}
+            >
+              Add a signature to use when signing documents.
+            </Text>
+          </View>
+        }
+        ListFooterComponent={
+          <Button
+            label="Add Signature"
+            variant="primary"
+            size="md"
+            onPress={onAdd}
+            testID="signature-add-button"
+            iconLeft={<Ionicons name="add" size={20} color="#fff" />}
+            style={{ marginTop: theme.spacing.md }}
+          />
+        }
+      />
+    </View>
+  );
+}
+
+// ─── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  card: {
+    overflow: 'hidden',
+  },
+  cardHeader: {},
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  defaultBadge: {},
+  cardActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  empty: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+SignatureList.displayName = 'SignatureList';

--- a/apps/mobile/src/components/signature/__tests__/SignatureList.test.ts
+++ b/apps/mobile/src/components/signature/__tests__/SignatureList.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { StoredSignature } from '@fillit/shared';
+
+import type { SignatureListProps } from '../SignatureList';
+
+// Verify the component module structure is importable
+describe('SignatureList', () => {
+  const mockSignatures: StoredSignature[] = [
+    {
+      id: 'sig-1',
+      profileId: 'profile-1',
+      type: 'drawn',
+      label: 'Full Name',
+      svgPath: 'M 10 20 L 30 40',
+      createdAt: '2026-03-29T00:00:00Z',
+      isDefault: true,
+    },
+    {
+      id: 'sig-2',
+      profileId: 'profile-1',
+      type: 'typed',
+      label: 'Initials',
+      text: 'RK',
+      fontFamily: 'DancingScript-Regular',
+      createdAt: '2026-03-29T01:00:00Z',
+      isDefault: false,
+    },
+  ];
+
+  it('should have correct props interface', () => {
+    const props: SignatureListProps = {
+      signatures: mockSignatures,
+      onAdd: vi.fn(),
+      onDelete: vi.fn(),
+      onSetDefault: vi.fn(),
+    };
+
+    expect(props.signatures).toHaveLength(2);
+    expect(props.signatures[0]!.isDefault).toBe(true);
+    expect(props.signatures[1]!.type).toBe('typed');
+  });
+
+  it('should accept empty signatures list', () => {
+    const props: SignatureListProps = {
+      signatures: [],
+      onAdd: vi.fn(),
+      onDelete: vi.fn(),
+      onSetDefault: vi.fn(),
+    };
+
+    expect(props.signatures).toHaveLength(0);
+  });
+
+  it('should handle signatures of both types', () => {
+    const drawnSig = mockSignatures.find((s) => s.type === 'drawn');
+    const typedSig = mockSignatures.find((s) => s.type === 'typed');
+
+    expect(drawnSig).toBeDefined();
+    expect(drawnSig!.svgPath).toBeDefined();
+    expect(typedSig).toBeDefined();
+    expect(typedSig!.text).toBeDefined();
+    expect(typedSig!.fontFamily).toBeDefined();
+  });
+});

--- a/apps/mobile/src/components/signature/index.ts
+++ b/apps/mobile/src/components/signature/index.ts
@@ -4,3 +4,5 @@ export { SignaturePreview } from './SignaturePreview';
 export type { SignaturePreviewProps, PreviewSize } from './SignaturePreview';
 export { TypedSignature } from './TypedSignature';
 export type { TypedSignatureProps, TypedSignatureResult, SignatureFont } from './TypedSignature';
+export { SignatureList } from './SignatureList';
+export type { SignatureListProps } from './SignatureList';

--- a/apps/mobile/src/stores/__tests__/signature-store-actions.test.ts
+++ b/apps/mobile/src/stores/__tests__/signature-store-actions.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for signature CRUD actions in the profile store.
+ *
+ * Verifies that createSignature, deleteSignature, setDefaultSignature,
+ * and updateSignature correctly update store state and call the service layer.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { StoredSignature, SignatureType } from '@fillit/shared';
+
+// ─── Mocks ────────────────────────────────────────────────────────
+
+const mockCreateSignature = vi.fn();
+const mockGetSignaturesByProfile = vi.fn();
+const mockUpdateSignature = vi.fn();
+const mockDeleteSignature = vi.fn();
+const mockSetDefaultSignature = vi.fn();
+
+vi.mock('../../services/storage/signatureService', () => ({
+  createSignature: (...args: unknown[]) => mockCreateSignature(...args),
+  getSignaturesByProfile: (...args: unknown[]) => mockGetSignaturesByProfile(...args),
+  updateSignature: (...args: unknown[]) => mockUpdateSignature(...args),
+  deleteSignature: (...args: unknown[]) => mockDeleteSignature(...args),
+  setDefaultSignature: (...args: unknown[]) => mockSetDefaultSignature(...args),
+}));
+
+vi.mock('../../services/storage/profileCrud', () => ({
+  listProfiles: vi.fn().mockResolvedValue([]),
+  createProfile: vi.fn(),
+  getProfileById: vi.fn(),
+  updateProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+  createAddress: vi.fn(),
+  getAddressesByProfileId: vi.fn(),
+  updateAddress: vi.fn(),
+  deleteAddress: vi.fn(),
+  createIdentityDocument: vi.fn(),
+  getIdentityDocumentsByProfileId: vi.fn(),
+  updateIdentityDocument: vi.fn(),
+  deleteIdentityDocument: vi.fn(),
+  createProfessionalRegistration: vi.fn(),
+  getProfessionalRegistrationsByProfileId: vi.fn(),
+  updateProfessionalRegistration: vi.fn(),
+  deleteProfessionalRegistration: vi.fn(),
+  createEmergencyContact: vi.fn(),
+  getEmergencyContactsByProfileId: vi.fn(),
+  updateEmergencyContact: vi.fn(),
+  deleteEmergencyContact: vi.fn(),
+  createFullProfile: vi.fn(),
+}));
+
+vi.mock('../../services/storage/database', () => ({
+  initializeDatabase: vi.fn().mockResolvedValue({}),
+}));
+
+import { useProfileStore } from '../profile-store';
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function makeSignature(overrides: Partial<StoredSignature> = {}): StoredSignature {
+  return {
+    id: 'sig-1',
+    profileId: 'profile-1',
+    type: 'drawn' as SignatureType,
+    label: 'Full Name',
+    svgPath: 'M 10 20 L 30 40',
+    createdAt: '2026-03-29T00:00:00Z',
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+function seedStore(signatures: StoredSignature[] = []) {
+  useProfileStore.setState({
+    profiles: [
+      {
+        id: 'profile-1',
+        isPrimary: true,
+        firstName: 'Test',
+        lastName: 'User',
+        email: 'test@test.com',
+        phone: '',
+        dateOfBirth: '',
+        idNumber: '',
+        gender: 'male',
+        title: 'Mr',
+        addresses: [],
+        documents: [],
+        professionalRegistrations: [],
+        emergencyContacts: [],
+        signatures,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ],
+    activeProfileId: 'profile-1',
+    isInitialized: true,
+    isLoading: false,
+    mutationCount: 0,
+    error: null,
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+describe('signature store actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProfileStore.getState().reset();
+  });
+
+  describe('createSignature', () => {
+    it('should create a signature and refresh the profile signatures', async () => {
+      seedStore();
+      const newSig = makeSignature({ id: 'sig-new', isDefault: true });
+      mockCreateSignature.mockResolvedValue(newSig);
+      mockGetSignaturesByProfile.mockResolvedValue([newSig]);
+
+      const result = await useProfileStore.getState().createSignature({
+        id: 'sig-new',
+        profileId: 'profile-1',
+        type: 'drawn',
+        label: 'Full Name',
+        svgPath: 'M 10 20 L 30 40',
+        isDefault: true,
+      });
+
+      expect(result.id).toBe('sig-new');
+      expect(mockCreateSignature).toHaveBeenCalledOnce();
+      expect(mockGetSignaturesByProfile).toHaveBeenCalledWith('profile-1');
+
+      const profile = useProfileStore.getState().profiles[0]!;
+      expect(profile.signatures).toHaveLength(1);
+      expect(profile.signatures[0]!.id).toBe('sig-new');
+    });
+
+    it('should set error on failure', async () => {
+      seedStore();
+      mockCreateSignature.mockRejectedValue(new Error('DB error'));
+
+      await expect(
+        useProfileStore.getState().createSignature({
+          id: 'sig-fail',
+          profileId: 'profile-1',
+          type: 'drawn',
+          label: 'Test',
+          svgPath: 'M 0 0',
+        }),
+      ).rejects.toThrow('DB error');
+
+      expect(useProfileStore.getState().error?.operation).toBe('createSignature');
+    });
+  });
+
+  describe('deleteSignature', () => {
+    it('should remove a signature from the store', async () => {
+      const sig = makeSignature();
+      seedStore([sig]);
+      mockDeleteSignature.mockResolvedValue(undefined);
+
+      await useProfileStore.getState().deleteSignature('sig-1', 'profile-1');
+
+      expect(mockDeleteSignature).toHaveBeenCalledWith('sig-1');
+      const profile = useProfileStore.getState().profiles[0]!;
+      expect(profile.signatures).toHaveLength(0);
+    });
+
+    it('should set error on failure', async () => {
+      const sig = makeSignature();
+      seedStore([sig]);
+      mockDeleteSignature.mockRejectedValue(new Error('Not found'));
+
+      await expect(
+        useProfileStore.getState().deleteSignature('sig-1', 'profile-1'),
+      ).rejects.toThrow('Not found');
+
+      expect(useProfileStore.getState().error?.operation).toBe('deleteSignature');
+    });
+  });
+
+  describe('setDefaultSignature', () => {
+    it('should update the default signature and refresh', async () => {
+      const sig1 = makeSignature({ id: 'sig-1', isDefault: true });
+      const sig2 = makeSignature({ id: 'sig-2', label: 'Initials', isDefault: false });
+      seedStore([sig1, sig2]);
+
+      const updatedSig2 = { ...sig2, isDefault: true };
+      mockSetDefaultSignature.mockResolvedValue(updatedSig2);
+      mockGetSignaturesByProfile.mockResolvedValue([{ ...sig1, isDefault: false }, updatedSig2]);
+
+      const result = await useProfileStore.getState().setDefaultSignature('sig-2', 'profile-1');
+
+      expect(result.isDefault).toBe(true);
+      expect(mockSetDefaultSignature).toHaveBeenCalledWith('sig-2');
+
+      const profile = useProfileStore.getState().profiles[0]!;
+      expect(profile.signatures.find((s) => s.id === 'sig-2')!.isDefault).toBe(true);
+      expect(profile.signatures.find((s) => s.id === 'sig-1')!.isDefault).toBe(false);
+    });
+  });
+
+  describe('updateSignature', () => {
+    it('should update a signature label', async () => {
+      const sig = makeSignature();
+      seedStore([sig]);
+
+      const updated = { ...sig, label: 'New Label' };
+      mockUpdateSignature.mockResolvedValue(updated);
+      mockGetSignaturesByProfile.mockResolvedValue([updated]);
+
+      const result = await useProfileStore
+        .getState()
+        .updateSignature('sig-1', 'profile-1', { label: 'New Label' });
+
+      expect(result.label).toBe('New Label');
+      expect(mockUpdateSignature).toHaveBeenCalledWith('sig-1', { label: 'New Label' });
+    });
+  });
+});

--- a/apps/mobile/src/stores/profile-store.ts
+++ b/apps/mobile/src/stores/profile-store.ts
@@ -11,6 +11,7 @@ import type {
   EmergencyContact,
   IdentityDocument,
   ProfessionalRegistration,
+  StoredSignature,
   UserProfile,
 } from '@fillit/shared';
 import { create } from 'zustand';
@@ -49,6 +50,15 @@ import {
   type CreateEmergencyContactInput,
   type UpdateEmergencyContactInput,
 } from '../services/storage/profileCrud';
+import {
+  createSignature as createProfileSignature,
+  getSignaturesByProfile,
+  updateSignature as updateProfileSignature,
+  deleteSignature as deleteProfileSignature,
+  setDefaultSignature as setProfileDefaultSignature,
+  type CreateSignatureInput,
+  type UpdateSignatureInput,
+} from '../services/storage/signatureService';
 import { initializeDatabase } from '../services/storage/database';
 
 // ---------------------------------------------------------------------------
@@ -98,7 +108,11 @@ export type ProfileOperation =
   | 'deleteProfessionalRegistration'
   | 'createEmergencyContact'
   | 'updateEmergencyContact'
-  | 'deleteEmergencyContact';
+  | 'deleteEmergencyContact'
+  | 'createSignature'
+  | 'updateSignature'
+  | 'deleteSignature'
+  | 'setDefaultSignature';
 
 /** Actions available on the profile store */
 export interface ProfileActions {
@@ -148,6 +162,14 @@ export interface ProfileActions {
     input: UpdateEmergencyContactInput,
   ) => Promise<EmergencyContact | null>;
   deleteEmergencyContact: (id: string, profileId: string) => Promise<boolean>;
+  createSignature: (input: CreateSignatureInput) => Promise<StoredSignature>;
+  updateSignature: (
+    id: string,
+    profileId: string,
+    input: UpdateSignatureInput,
+  ) => Promise<StoredSignature>;
+  deleteSignature: (id: string, profileId: string) => Promise<void>;
+  setDefaultSignature: (id: string, profileId: string) => Promise<StoredSignature>;
   clearError: () => void;
   reset: () => void;
 }
@@ -602,6 +624,66 @@ function createEmergencyContactActions({
   };
 }
 
+function createSignatureActions({
+  startMutation,
+  endMutationWithError,
+  updateProfileChildren,
+}: ReturnType<typeof createMutationHelpers>) {
+  return {
+    createSignature: async (input: CreateSignatureInput) => {
+      startMutation();
+      try {
+        const sig = await createProfileSignature(input);
+        const signatures = await getSignaturesByProfile(input.profileId);
+        updateProfileChildren(input.profileId, () => ({ signatures }));
+        return sig;
+      } catch (err) {
+        endMutationWithError('createSignature', err);
+        throw err;
+      }
+    },
+
+    updateSignature: async (id: string, profileId: string, input: UpdateSignatureInput) => {
+      startMutation();
+      try {
+        const updated = await updateProfileSignature(id, input);
+        const signatures = await getSignaturesByProfile(profileId);
+        updateProfileChildren(profileId, () => ({ signatures }));
+        return updated;
+      } catch (err) {
+        endMutationWithError('updateSignature', err);
+        throw err;
+      }
+    },
+
+    deleteSignature: async (id: string, profileId: string) => {
+      startMutation();
+      try {
+        await deleteProfileSignature(id);
+        updateProfileChildren(profileId, (p) => ({
+          signatures: p.signatures.filter((s: StoredSignature) => s.id !== id),
+        }));
+      } catch (err) {
+        endMutationWithError('deleteSignature', err);
+        throw err;
+      }
+    },
+
+    setDefaultSignature: async (id: string, profileId: string) => {
+      startMutation();
+      try {
+        const updated = await setProfileDefaultSignature(id);
+        const signatures = await getSignaturesByProfile(profileId);
+        updateProfileChildren(profileId, () => ({ signatures }));
+        return updated;
+      } catch (err) {
+        endMutationWithError('setDefaultSignature', err);
+        throw err;
+      }
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
@@ -620,6 +702,7 @@ function createProfileStore(set: SetFn, get: GetFn): ProfileStore {
     ...createIdentityDocumentActions(mutationHelpers),
     ...createProfessionalRegistrationActions(mutationHelpers),
     ...createEmergencyContactActions(mutationHelpers),
+    ...createSignatureActions(mutationHelpers),
     clearError: () => set({ error: null }),
     reset: () => set({ ...DEFAULT_PROFILE_STATE }),
   };
@@ -671,6 +754,10 @@ export const selectActiveProfileRegistrations = (state: ProfileStore): Professio
 /** Select emergency contacts for the active profile */
 export const selectActiveProfileEmergencyContacts = (state: ProfileStore): EmergencyContact[] =>
   state.profiles.find((p) => p.id === state.activeProfileId)?.emergencyContacts ?? [];
+
+/** Select signatures for the active profile */
+export const selectActiveProfileSignatures = (state: ProfileStore): StoredSignature[] =>
+  state.profiles.find((p) => p.id === state.activeProfileId)?.signatures ?? [];
 
 /** Select whether profiles are loading */
 export const selectIsLoading = (state: ProfileStore): boolean => state.isLoading;


### PR DESCRIPTION
## Summary
- Adds signature CRUD actions to the profile Zustand store (create, update, delete, set default)
- Adds `SignatureList` component displaying saved signatures with previews, default badges, and delete/set-default actions
- Adds signature management screen listing all saved signatures for the active profile
- Adds signature creation screen supporting both drawn (SVG canvas) and typed (text + font) modes
- Adds "Signatures" navigation button to the profiles tab
- Includes unit tests for store actions (6 tests) and component interface (3 tests)

Closes #72

## Test plan
- [ ] Navigate to Profiles tab → tap "Signatures" → verify empty state message
- [ ] Tap "Add Signature" → draw a signature → enter label → save → verify it appears in the list
- [ ] Add a typed signature → verify font selector and preview work
- [ ] First signature is automatically set as default (badge shown)
- [ ] Tap "Set default" on a non-default signature → verify badge moves
- [ ] Tap "Delete" → confirm alert → verify signature removed from list
- [ ] Verify all 9 new tests pass (`vitest run src/stores/__tests__/signature-store-actions.test.ts src/components/signature/__tests__/SignatureList.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)