### PR TITLE
feat(mobile): add PDF form-fill generation service (S-73)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,6 +40,7 @@
     "expo-sqlite": "^55.0.11",
     "expo-status-bar": "~55.0.4",
     "metro-runtime": "^0.84.2",
+    "pdf-lib": "^1.17.1",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",

--- a/apps/mobile/src/services/pdf/__tests__/formFill.test.ts
+++ b/apps/mobile/src/services/pdf/__tests__/formFill.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for PDF form-fill service.
+ *
+ * Uses pdf-lib to create test PDFs with AcroForm fields,
+ * then verifies the fill logic, date formatting, and field mapping.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PDFDocument } from 'pdf-lib';
+import type { DetectedField } from '@fillit/shared';
+
+import {
+  fillPdfForm,
+  formatDateSA,
+  listPdfFormFields,
+  mapDetectedFieldsToFormValues,
+  type FormFieldValue,
+} from '../formFill';
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Create a test PDF with AcroForm fields.
+ */
+async function createTestPdf(): Promise<Uint8Array> {
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([600, 400]);
+  const form = pdfDoc.getForm();
+
+  // Add text fields
+  const firstNameField = form.createTextField('firstName');
+  firstNameField.addToPage(page, { x: 50, y: 350, width: 200, height: 20 });
+
+  const lastNameField = form.createTextField('lastName');
+  lastNameField.addToPage(page, { x: 50, y: 320, width: 200, height: 20 });
+
+  const dateField = form.createTextField('dateOfBirth');
+  dateField.addToPage(page, { x: 50, y: 290, width: 200, height: 20 });
+
+  const emailField = form.createTextField('email');
+  emailField.addToPage(page, { x: 50, y: 260, width: 200, height: 20 });
+
+  // Add checkbox
+  const consentField = form.createCheckBox('consent');
+  consentField.addToPage(page, { x: 50, y: 230, width: 15, height: 15 });
+
+  return await pdfDoc.save();
+}
+
+// ─── formatDateSA ─────────────────────────────────────────────────
+
+describe('formatDateSA', () => {
+  it('should format ISO date to DD/MM/YYYY', () => {
+    expect(formatDateSA('2026-03-29T00:00:00Z')).toBe('29/03/2026');
+  });
+
+  it('should format YYYY-MM-DD to DD/MM/YYYY', () => {
+    expect(formatDateSA('1990-12-25')).toBe('25/12/1990');
+  });
+
+  it('should return already-formatted DD/MM/YYYY unchanged', () => {
+    expect(formatDateSA('25/12/1990')).toBe('25/12/1990');
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(formatDateSA('')).toBe('');
+  });
+
+  it('should return unparseable string unchanged', () => {
+    expect(formatDateSA('not-a-date')).toBe('not-a-date');
+  });
+
+  it('should handle date with timezone', () => {
+    const result = formatDateSA('2026-01-15T12:30:00+02:00');
+    // The exact day may shift depending on UTC offset handling
+    expect(result).toMatch(/^\d{2}\/\d{2}\/2026$/);
+  });
+});
+
+// ─── mapDetectedFieldsToFormValues ───────────────────────────────
+
+describe('mapDetectedFieldsToFormValues', () => {
+  const baseField: DetectedField = {
+    id: 'f-1',
+    pageId: 'p-1',
+    label: 'First Name',
+    normalizedLabel: 'first_name',
+    fieldType: 'text',
+    bounds: { x: 0, y: 0, width: 100, height: 20 },
+    matchedProfileField: 'firstName',
+    matchConfidence: 0.9,
+    value: 'John',
+    isConfirmed: true,
+    isSignatureField: false,
+  };
+
+  it('should map confirmed fields with values', () => {
+    const result = mapDetectedFieldsToFormValues([baseField]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      fieldName: 'firstName',
+      value: 'John',
+      fieldType: 'text',
+    });
+  });
+
+  it('should use normalizedLabel when matchedProfileField is missing', () => {
+    const field = { ...baseField, matchedProfileField: undefined };
+    const result = mapDetectedFieldsToFormValues([field]);
+    expect(result[0]!.fieldName).toBe('first_name');
+  });
+
+  it('should fall back to label when normalizedLabel is also empty', () => {
+    const field = { ...baseField, matchedProfileField: undefined, normalizedLabel: '' };
+    const result = mapDetectedFieldsToFormValues([field]);
+    expect(result[0]!.fieldName).toBe('First Name');
+  });
+
+  it('should exclude unconfirmed fields', () => {
+    const field = { ...baseField, isConfirmed: false };
+    const result = mapDetectedFieldsToFormValues([field]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should exclude empty-value fields', () => {
+    const field = { ...baseField, value: '' };
+    const result = mapDetectedFieldsToFormValues([field]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should exclude signature fields', () => {
+    const field = { ...baseField, isSignatureField: true };
+    const result = mapDetectedFieldsToFormValues([field]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle multiple fields', () => {
+    const fields = [
+      baseField,
+      {
+        ...baseField,
+        id: 'f-2',
+        label: 'Last Name',
+        matchedProfileField: 'lastName',
+        value: 'Doe',
+      },
+      { ...baseField, id: 'f-3', isConfirmed: false, value: 'ignored' },
+    ];
+    const result = mapDetectedFieldsToFormValues(fields);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ─── fillPdfForm ─────────────────────────────────────────────────
+
+describe('fillPdfForm', () => {
+  it('should fill text fields in a PDF', async () => {
+    const pdfBytes = await createTestPdf();
+    const fieldValues: FormFieldValue[] = [
+      { fieldName: 'firstName', value: 'John', fieldType: 'text' },
+      { fieldName: 'lastName', value: 'Doe', fieldType: 'text' },
+    ];
+
+    const result = await fillPdfForm(new Uint8Array(pdfBytes), fieldValues);
+
+    expect(result.filledCount).toBe(2);
+    expect(result.skippedCount).toBe(0);
+    expect(result.skippedFields).toEqual([]);
+    expect(result.pdfBytes).toBeInstanceOf(Uint8Array);
+    expect(result.pdfBytes.length).toBeGreaterThan(0);
+
+    // Verify the values were actually set by reloading the PDF
+    const filledPdf = await PDFDocument.load(result.pdfBytes);
+    const form = filledPdf.getForm();
+    expect(form.getTextField('firstName').getText()).toBe('John');
+    expect(form.getTextField('lastName').getText()).toBe('Doe');
+  });
+
+  it('should format date fields in SA format', async () => {
+    const pdfBytes = await createTestPdf();
+    const fieldValues: FormFieldValue[] = [
+      { fieldName: 'dateOfBirth', value: '1990-12-25', fieldType: 'date' },
+    ];
+
+    const result = await fillPdfForm(new Uint8Array(pdfBytes), fieldValues);
+
+    expect(result.filledCount).toBe(1);
+
+    const filledPdf = await PDFDocument.load(result.pdfBytes);
+    const form = filledPdf.getForm();
+    expect(form.getTextField('dateOfBirth').getText()).toBe('25/12/1990');
+  });
+
+  it('should check checkboxes', async () => {
+    const pdfBytes = await createTestPdf();
+    const fieldValues: FormFieldValue[] = [
+      { fieldName: 'consent', value: 'true', fieldType: 'checkbox' },
+    ];
+
+    const result = await fillPdfForm(new Uint8Array(pdfBytes), fieldValues);
+
+    expect(result.filledCount).toBe(1);
+
+    const filledPdf = await PDFDocument.load(result.pdfBytes);
+    const form = filledPdf.getForm();
+    expect(form.getCheckBox('consent').isChecked()).toBe(true);
+  });
+
+  it('should uncheck checkboxes for falsy values', async () => {
+    const pdfBytes = await createTestPdf();
+
+    // First check it
+    const preResult = await fillPdfForm(new Uint8Array(pdfBytes), [
+      { fieldName: 'consent', value: 'yes', fieldType: 'checkbox' },
+    ]);
+
+    // Then uncheck it
+    const result = await fillPdfForm(preResult.pdfBytes, [
+      { fieldName: 'consent', value: 'no', fieldType: 'checkbox' },
+    ]);
+
+    const filledPdf = await PDFDocument.load(result.pdfBytes);
+    const form = filledPdf.getForm();
+    expect(form.getCheckBox('consent').isChecked()).toBe(false);
+  });
+
+  it('should skip fields not found in the PDF', async () => {
+    const pdfBytes = await createTestPdf();
+    const fieldValues: FormFieldValue[] = [
+      { fieldName: 'firstName', value: 'John', fieldType: 'text' },
+      { fieldName: 'nonExistentField', value: 'ignored', fieldType: 'text' },
+    ];
+
+    const result = await fillPdfForm(new Uint8Array(pdfBytes), fieldValues);
+
+    expect(result.filledCount).toBe(1);
+    expect(result.skippedCount).toBe(1);
+    expect(result.skippedFields).toEqual(['nonExistentField']);
+  });
+
+  it('should handle empty field values list', async () => {
+    const pdfBytes = await createTestPdf();
+    const result = await fillPdfForm(new Uint8Array(pdfBytes), []);
+
+    expect(result.filledCount).toBe(0);
+    expect(result.skippedCount).toBe(0);
+    expect(result.pdfBytes.length).toBeGreaterThan(0);
+  });
+
+  it('should flatten the form when requested', async () => {
+    const pdfBytes = await createTestPdf();
+    const fieldValues: FormFieldValue[] = [
+      { fieldName: 'firstName', value: 'John', fieldType: 'text' },
+    ];
+
+    const result = await fillPdfForm(new Uint8Array(pdfBytes), fieldValues, { flatten: true });
+
+    expect(result.filledCount).toBe(1);
+
+    // After flattening, fields should not be editable
+    const filledPdf = await PDFDocument.load(result.pdfBytes);
+    const form = filledPdf.getForm();
+    expect(form.getFields()).toHaveLength(0);
+  });
+
+  it('should handle various checkbox truthy values', async () => {
+    const truthyValues = ['true', 'yes', '1', 'on', 'checked', 'x', 'YES', 'True'];
+    const pdfBytes = await createTestPdf();
+
+    for (const val of truthyValues) {
+      const result = await fillPdfForm(new Uint8Array(pdfBytes), [
+        { fieldName: 'consent', value: val, fieldType: 'checkbox' },
+      ]);
+      const pdf = await PDFDocument.load(result.pdfBytes);
+      expect(pdf.getForm().getCheckBox('consent').isChecked()).toBe(true);
+    }
+  });
+
+  it('should handle checkbox falsy values', async () => {
+    const falsyValues = ['false', 'no', '0', 'off', '', 'anything-else'];
+    const pdfBytes = await createTestPdf();
+
+    for (const val of falsyValues) {
+      const result = await fillPdfForm(new Uint8Array(pdfBytes), [
+        { fieldName: 'consent', value: val, fieldType: 'checkbox' },
+      ]);
+      const pdf = await PDFDocument.load(result.pdfBytes);
+      expect(pdf.getForm().getCheckBox('consent').isChecked()).toBe(false);
+    }
+  });
+});
+
+// ─── listPdfFormFields ────────────────────────────────────────────
+
+describe('listPdfFormFields', () => {
+  it('should list all form fields', async () => {
+    const pdfBytes = await createTestPdf();
+    const fields = await listPdfFormFields(new Uint8Array(pdfBytes));
+
+    expect(fields).toHaveLength(5);
+    const names = fields.map((f) => f.name);
+    expect(names).toContain('firstName');
+    expect(names).toContain('lastName');
+    expect(names).toContain('dateOfBirth');
+    expect(names).toContain('email');
+    expect(names).toContain('consent');
+  });
+
+  it('should identify field types', async () => {
+    const pdfBytes = await createTestPdf();
+    const fields = await listPdfFormFields(new Uint8Array(pdfBytes));
+
+    const consent = fields.find((f) => f.name === 'consent');
+    expect(consent?.type).toBe('PDFCheckBox');
+
+    const firstName = fields.find((f) => f.name === 'firstName');
+    expect(firstName?.type).toBe('PDFTextField');
+  });
+
+  it('should return empty array for PDF without forms', async () => {
+    const pdfDoc = await PDFDocument.create();
+    pdfDoc.addPage();
+    const pdfBytes = await pdfDoc.save();
+
+    const fields = await listPdfFormFields(new Uint8Array(pdfBytes));
+    expect(fields).toHaveLength(0);
+  });
+});

--- a/apps/mobile/src/services/pdf/formFill.ts
+++ b/apps/mobile/src/services/pdf/formFill.ts
@@ -1,0 +1,186 @@
+/**
+ * PDF form-fill service using pdf-lib.
+ *
+ * Fills AcroForm fields in existing form-fillable PDFs based on
+ * detected/confirmed field values. Supports text, date, checkbox,
+ * and number fields. Dates are formatted in SA format (DD/MM/YYYY).
+ */
+
+import { PDFDocument, PDFCheckBox, PDFTextField, PDFRadioGroup, PDFDropdown } from 'pdf-lib';
+import type { DetectedField, DetectedFieldType } from '@fillit/shared';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+/** A field value to fill into the PDF form. */
+export interface FormFieldValue {
+  /** The AcroForm field name in the PDF. */
+  fieldName: string;
+  /** The value to set. */
+  value: string;
+  /** The detected field type (influences formatting). */
+  fieldType: DetectedFieldType;
+}
+
+/** Options for the form-fill operation. */
+export interface FormFillOptions {
+  /** Whether to flatten the form after filling (makes fields non-editable). @default false */
+  flatten?: boolean;
+}
+
+/** Result of the form-fill operation. */
+export interface FormFillResult {
+  /** The filled PDF as a Uint8Array. */
+  pdfBytes: Uint8Array;
+  /** Number of fields that were successfully filled. */
+  filledCount: number;
+  /** Number of fields that were skipped (not found in PDF). */
+  skippedCount: number;
+  /** Field names that were skipped. */
+  skippedFields: string[];
+}
+
+// ─── Date Formatting ──────────────────────────────────────────────
+
+/**
+ * Format a date string to South African format (DD/MM/YYYY).
+ *
+ * Accepts ISO 8601 dates, YYYY-MM-DD, MM/DD/YYYY, and other
+ * common date formats. Returns the original string if parsing fails.
+ */
+export function formatDateSA(dateStr: string): string {
+  if (!dateStr) return dateStr;
+
+  // Try parsing as a Date
+  const date = new Date(dateStr);
+  if (!isNaN(date.getTime())) {
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    return `${day}/${month}/${year}`;
+  }
+
+  // Already in DD/MM/YYYY format?
+  if (/^\d{2}\/\d{2}\/\d{4}$/.test(dateStr)) {
+    return dateStr;
+  }
+
+  return dateStr;
+}
+
+// ─── Field Mapping ────────────────────────────────────────────────
+
+/**
+ * Convert detected fields to form field values.
+ *
+ * Only includes fields that have a value and are confirmed.
+ * Signature fields are excluded (handled separately).
+ */
+export function mapDetectedFieldsToFormValues(fields: DetectedField[]): FormFieldValue[] {
+  return fields
+    .filter((f) => f.value && f.isConfirmed && !f.isSignatureField)
+    .map((f) => ({
+      fieldName: f.matchedProfileField || f.normalizedLabel || f.label,
+      value: f.value,
+      fieldType: f.fieldType,
+    }));
+}
+
+// ─── Form Fill ────────────────────────────────────────────────────
+
+/**
+ * Fill AcroForm fields in a PDF document.
+ *
+ * @param pdfBytes - The source PDF file as bytes.
+ * @param fieldValues - The field values to fill.
+ * @param options - Optional fill options.
+ * @returns The filled PDF bytes and fill statistics.
+ */
+export async function fillPdfForm(
+  pdfBytes: Uint8Array,
+  fieldValues: FormFieldValue[],
+  options: FormFillOptions = {},
+): Promise<FormFillResult> {
+  const pdfDoc = await PDFDocument.load(pdfBytes, {
+    ignoreEncryption: true,
+  });
+
+  const form = pdfDoc.getForm();
+  let filledCount = 0;
+  const skippedFields: string[] = [];
+
+  for (const fv of fieldValues) {
+    try {
+      const field = form.getField(fv.fieldName);
+
+      if (field instanceof PDFTextField) {
+        const value = fv.fieldType === 'date' ? formatDateSA(fv.value) : fv.value;
+        field.setText(value);
+        filledCount++;
+      } else if (field instanceof PDFCheckBox) {
+        const isChecked = isCheckboxChecked(fv.value);
+        if (isChecked) {
+          field.check();
+        } else {
+          field.uncheck();
+        }
+        filledCount++;
+      } else if (field instanceof PDFRadioGroup) {
+        field.select(fv.value);
+        filledCount++;
+      } else if (field instanceof PDFDropdown) {
+        field.select(fv.value);
+        filledCount++;
+      } else {
+        // Unknown field type — skip
+        skippedFields.push(fv.fieldName);
+      }
+    } catch {
+      // Field not found in the form
+      skippedFields.push(fv.fieldName);
+    }
+  }
+
+  if (options.flatten) {
+    form.flatten();
+  }
+
+  const resultBytes = await pdfDoc.save();
+
+  return {
+    pdfBytes: resultBytes,
+    filledCount,
+    skippedCount: skippedFields.length,
+    skippedFields,
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Determine if a string value represents a checked checkbox.
+ */
+function isCheckboxChecked(value: string): boolean {
+  const normalized = value.toLowerCase().trim();
+  return ['true', 'yes', '1', 'on', 'checked', 'x'].includes(normalized);
+}
+
+/**
+ * List all AcroForm field names in a PDF.
+ *
+ * Useful for debugging and matching detected fields to PDF form fields.
+ */
+export async function listPdfFormFields(
+  pdfBytes: Uint8Array,
+): Promise<Array<{ name: string; type: string }>> {
+  const pdfDoc = await PDFDocument.load(pdfBytes, {
+    ignoreEncryption: true,
+  });
+
+  const form = pdfDoc.getForm();
+  const fields = form.getFields();
+
+  return fields.map((f) => ({
+    name: f.getName(),
+    type: f.constructor.name,
+  }));
+}

--- a/apps/mobile/src/services/pdf/index.ts
+++ b/apps/mobile/src/services/pdf/index.ts
@@ -1,0 +1,7 @@
+export {
+  fillPdfForm,
+  formatDateSA,
+  listPdfFormFields,
+  mapDetectedFieldsToFormValues,
+} from './formFill';
+export type { FormFieldValue, FormFillOptions, FormFillResult } from './formFill';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       metro-runtime:
         specifier: ^0.84.2
         version: 0.84.2
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -1210,6 +1213,12 @@ packages:
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -3447,6 +3456,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3480,6 +3492,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3991,6 +4006,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -5575,6 +5593,14 @@ snapshots:
 
   '@oxc-project/types@0.115.0': {}
 
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-collection@1.1.7(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -6004,9 +6030,7 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.83.2': {}
 
@@ -8169,6 +8193,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -8193,6 +8219,13 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   picocolors@1.1.1: {}
 
@@ -8713,6 +8746,8 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## Summary
- Adds `pdf-lib` dependency for AcroForm PDF manipulation
- Adds `formFill` service that fills text fields, checkboxes, radio buttons, and dropdowns in existing PDFs
- Formats date fields in South African format (DD/MM/YYYY)
- Maps `DetectedField` objects to PDF form field values (excluding unconfirmed and signature fields)
- Supports optional form flattening to make filled fields non-editable
- Includes `listPdfFormFields` utility for debugging field name matching
- 25 comprehensive tests covering all field types, edge cases, and flattening

Closes #74

## Test plan
- [ ] Run `vitest run src/services/pdf/__tests__/formFill.test.ts` — all 25 tests pass
- [ ] Verify text fields are filled correctly
- [ ] Verify date fields are formatted as DD/MM/YYYY
- [ ] Verify checkboxes respond to truthy/falsy values
- [ ] Verify non-existent fields are gracefully skipped
- [ ] Verify form flattening removes editable fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)