### PR TITLE
feat(server): add usage stats endpoint (S-54)

### DIFF
--- a/apps/server/src/__tests__/usage-stats.test.ts
+++ b/apps/server/src/__tests__/usage-stats.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for usage stats service and endpoint.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usageStats } from '../services/usage-stats.js';
+
+describe('UsageStatsService', () => {
+  beforeEach(() => {
+    usageStats.resetAll();
+  });
+
+  describe('record', () => {
+    it('should record a basic usage event', () => {
+      usageStats.record({ userId: 'user-1', cached: false });
+
+      const stats = usageStats.getStats('user-1');
+      expect(stats.allTime.requestCount).toBe(1);
+      expect(stats.allTime.cacheHits).toBe(0);
+    });
+
+    it('should track cache hits', () => {
+      usageStats.record({ userId: 'user-1', cached: true });
+
+      const stats = usageStats.getStats('user-1');
+      expect(stats.allTime.cacheHits).toBe(1);
+      expect(stats.allTime.requestCount).toBe(1);
+    });
+
+    it('should accumulate token usage', () => {
+      usageStats.record({
+        userId: 'user-1',
+        cached: false,
+        inputTokens: 100,
+        outputTokens: 50,
+      });
+      usageStats.record({
+        userId: 'user-1',
+        cached: false,
+        inputTokens: 200,
+        outputTokens: 75,
+      });
+
+      const stats = usageStats.getStats('user-1');
+      expect(stats.allTime.inputTokens).toBe(300);
+      expect(stats.allTime.outputTokens).toBe(125);
+      expect(stats.allTime.requestCount).toBe(2);
+    });
+
+    it('should track errors', () => {
+      usageStats.record({ userId: 'user-1', cached: false, isError: true });
+
+      const stats = usageStats.getStats('user-1');
+      expect(stats.allTime.errorCount).toBe(1);
+    });
+
+    it('should track per-day stats', () => {
+      usageStats.record({ userId: 'user-1', cached: false });
+
+      const stats = usageStats.getStats('user-1');
+      expect(stats.today.requestCount).toBe(1);
+    });
+
+    it('should track per-month stats', () => {
+      usageStats.record({ userId: 'user-1', cached: true });
+
+      const stats = usageStats.getStats('user-1');
+      expect(stats.thisMonth.requestCount).toBe(1);
+      expect(stats.thisMonth.cacheHits).toBe(1);
+    });
+
+    it('should isolate users', () => {
+      usageStats.record({ userId: 'user-1', cached: false });
+      usageStats.record({ userId: 'user-2', cached: false });
+      usageStats.record({ userId: 'user-2', cached: false });
+
+      expect(usageStats.getStats('user-1').allTime.requestCount).toBe(1);
+      expect(usageStats.getStats('user-2').allTime.requestCount).toBe(2);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return empty stats for unknown user', () => {
+      const stats = usageStats.getStats('unknown');
+
+      expect(stats.userId).toBe('unknown');
+      expect(stats.allTime.requestCount).toBe(0);
+      expect(stats.today.requestCount).toBe(0);
+      expect(stats.thisMonth.requestCount).toBe(0);
+    });
+
+    it('should include timestamps', () => {
+      usageStats.record({ userId: 'user-1', cached: false });
+
+      const stats = usageStats.getStats('user-1');
+      expect(stats.firstSeenAt).toBeDefined();
+      expect(stats.lastActivityAt).toBeDefined();
+      expect(new Date(stats.firstSeenAt).getTime()).toBeGreaterThan(0);
+    });
+  });
+
+  describe('resetUser', () => {
+    it('should reset a specific user', () => {
+      usageStats.record({ userId: 'user-1', cached: false });
+      usageStats.record({ userId: 'user-2', cached: false });
+
+      usageStats.resetUser('user-1');
+
+      expect(usageStats.getStats('user-1').allTime.requestCount).toBe(0);
+      expect(usageStats.getStats('user-2').allTime.requestCount).toBe(1);
+    });
+  });
+});

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -12,6 +12,7 @@ import {
 import { createVerifiers } from './auth/index.js';
 import { RateLimiter, RATE_LIMIT_TIERS } from './services/rate-limiter.js';
 import { analyzeRoutes } from './routes/analyze.js';
+import { usageRoutes } from './routes/usage.js';
 
 const app = new Hono<AppEnv>();
 
@@ -51,6 +52,7 @@ app.get('/', (c) => {
 
 // API routes
 app.route('/api', analyzeRoutes);
+app.route('/api', usageRoutes);
 
 // Authenticated route: verify token and return user info
 app.get('/api/auth/me', (c) => {

--- a/apps/server/src/routes/usage.ts
+++ b/apps/server/src/routes/usage.ts
@@ -1,0 +1,28 @@
+/**
+ * Usage stats API route.
+ *
+ * GET /api/usage — Returns authenticated user's usage statistics
+ * with daily, monthly, and all-time breakdowns.
+ */
+
+import { Hono } from 'hono';
+import type { AppEnv } from '../types.js';
+import { usageStats } from '../services/usage-stats.js';
+
+export const usageRoutes = new Hono<AppEnv>();
+
+/**
+ * GET /usage
+ *
+ * Returns the authenticated user's usage statistics.
+ * Requires authentication (userId from auth middleware).
+ */
+usageRoutes.get('/usage', (c) => {
+  const userId = c.get('userId');
+  const stats = usageStats.getStats(userId);
+
+  return c.json({
+    success: true,
+    data: stats,
+  });
+});

--- a/apps/server/src/services/usage-stats.ts
+++ b/apps/server/src/services/usage-stats.ts
@@ -1,0 +1,181 @@
+/**
+ * Per-user usage statistics service.
+ *
+ * Tracks API request counts, cache hits, and token usage per user
+ * with daily and monthly breakdowns. In-memory storage — resets
+ * on server restart (suitable for MVP, upgrade to Redis/DB later).
+ */
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface UsagePeriod {
+  /** Total analyze requests in this period. */
+  requestCount: number;
+  /** Number of cache hits (no Claude API call needed). */
+  cacheHits: number;
+  /** Total input tokens consumed (Claude API). */
+  inputTokens: number;
+  /** Total output tokens consumed (Claude API). */
+  outputTokens: number;
+  /** Number of errors encountered. */
+  errorCount: number;
+}
+
+export interface UserUsageStats {
+  userId: string;
+  /** Stats for the current day (UTC). */
+  today: UsagePeriod;
+  /** Stats for the current month (UTC). */
+  thisMonth: UsagePeriod;
+  /** All-time cumulative stats. */
+  allTime: UsagePeriod;
+  /** When the user's stats were first recorded. */
+  firstSeenAt: string;
+  /** When the user's stats were last updated. */
+  lastActivityAt: string;
+}
+
+export interface RecordUsageInput {
+  userId: string;
+  cached: boolean;
+  inputTokens?: number;
+  outputTokens?: number;
+  isError?: boolean;
+}
+
+// ─── Internal Types ───────────────────────────────────────────────
+
+interface UserRecord {
+  allTime: UsagePeriod;
+  /** Daily stats keyed by YYYY-MM-DD. */
+  daily: Map<string, UsagePeriod>;
+  /** Monthly stats keyed by YYYY-MM. */
+  monthly: Map<string, UsagePeriod>;
+  firstSeenAt: string;
+  lastActivityAt: string;
+}
+
+// ─── Service ──────────────────────────────────────────────────────
+
+class UsageStatsService {
+  private users = new Map<string, UserRecord>();
+
+  /**
+   * Record a usage event for a user.
+   */
+  record(input: RecordUsageInput): void {
+    const record = this.getOrCreateRecord(input.userId);
+    const now = new Date();
+    const dayKey = toDateKey(now);
+    const monthKey = toMonthKey(now);
+
+    // Get or create period records
+    const daily = getOrCreatePeriod(record.daily, dayKey);
+    const monthly = getOrCreatePeriod(record.monthly, monthKey);
+
+    // Update all periods
+    const periods = [record.allTime, daily, monthly];
+    for (const period of periods) {
+      period.requestCount++;
+      if (input.cached) period.cacheHits++;
+      if (input.inputTokens) period.inputTokens += input.inputTokens;
+      if (input.outputTokens) period.outputTokens += input.outputTokens;
+      if (input.isError) period.errorCount++;
+    }
+
+    record.lastActivityAt = now.toISOString();
+  }
+
+  /**
+   * Get usage stats for a user.
+   */
+  getStats(userId: string): UserUsageStats {
+    const record = this.users.get(userId);
+    const now = new Date();
+    const dayKey = toDateKey(now);
+    const monthKey = toMonthKey(now);
+
+    if (!record) {
+      return {
+        userId,
+        today: emptyPeriod(),
+        thisMonth: emptyPeriod(),
+        allTime: emptyPeriod(),
+        firstSeenAt: now.toISOString(),
+        lastActivityAt: now.toISOString(),
+      };
+    }
+
+    return {
+      userId,
+      today: record.daily.get(dayKey) ?? emptyPeriod(),
+      thisMonth: record.monthly.get(monthKey) ?? emptyPeriod(),
+      allTime: { ...record.allTime },
+      firstSeenAt: record.firstSeenAt,
+      lastActivityAt: record.lastActivityAt,
+    };
+  }
+
+  /**
+   * Reset stats for a user (for testing).
+   */
+  resetUser(userId: string): void {
+    this.users.delete(userId);
+  }
+
+  /**
+   * Reset all stats (for testing).
+   */
+  resetAll(): void {
+    this.users.clear();
+  }
+
+  // ─── Private ─────────────────────────────────────────────────
+
+  private getOrCreateRecord(userId: string): UserRecord {
+    let record = this.users.get(userId);
+    if (!record) {
+      record = {
+        allTime: emptyPeriod(),
+        daily: new Map(),
+        monthly: new Map(),
+        firstSeenAt: new Date().toISOString(),
+        lastActivityAt: new Date().toISOString(),
+      };
+      this.users.set(userId, record);
+    }
+    return record;
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function emptyPeriod(): UsagePeriod {
+  return {
+    requestCount: 0,
+    cacheHits: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    errorCount: 0,
+  };
+}
+
+function getOrCreatePeriod(map: Map<string, UsagePeriod>, key: string): UsagePeriod {
+  let period = map.get(key);
+  if (!period) {
+    period = emptyPeriod();
+    map.set(key, period);
+  }
+  return period;
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function toMonthKey(date: Date): string {
+  return date.toISOString().slice(0, 7);
+}
+
+/** Singleton usage stats service instance. */
+export const usageStats = new UsageStatsService();


### PR DESCRIPTION
## Summary
- Adds `UsageStatsService` for per-user usage tracking with daily, monthly, and all-time breakdowns
- Tracks request count, cache hits, input/output token usage, and error count
- Adds `GET /api/usage` authenticated endpoint returning the calling user's statistics
- In-memory storage (suitable for MVP, upgrade to Redis/DB for persistence later)
- User isolation — each user only sees their own stats
- 10 tests covering recording, accumulation, user isolation, period tracking, and reset

Closes #55

## Test plan
- [ ] Run `pnpm --filter server test` — all 135 tests pass (10 new)
- [ ] `GET /api/usage` with valid auth returns user stats
- [ ] Verify daily/monthly/allTime periods track correctly
- [ ] Verify cache hits and token usage accumulate
- [ ] Verify users are isolated (user A can't see user B's stats)
- [ ] Verify empty stats returned for new users

🤖 Generated with [Claude Code](https://claude.com/claude-code)