### PR TITLE
feat(mobile): build sign-in screen and auth guard (S-58)

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -36,6 +36,7 @@ function RootNavigator() {
         contentStyle: { backgroundColor: theme.colors.background },
       }}
     >
+      <Stack.Screen name="signin" options={{ headerShown: false }} />
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="profile/create" options={{ headerShown: false }} />
       <Stack.Screen name="profile/edit" options={{ headerShown: false }} />

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,12 +1,76 @@
 /**
- * Root index screen — redirects to the (tabs) group.
+ * Root index screen — auth guard redirect.
  *
- * This file handles the entry redirect from `/` to `/(tabs)/home`
- * so the app always lands on the Home tab.
+ * Checks authentication state and redirects to either
+ * the sign-in screen or the main app (tabs).
  */
 
+import { useEffect } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { Redirect } from 'expo-router';
 
+import { useTheme } from '../src/theme';
+import { useAuthStore, selectIsAuthenticated, selectAuthIsReady } from '../src/stores/auth-store';
+import { silentSignIn, getAuthToken } from '../src/services/auth';
+
 export default function IndexScreen() {
-  return <Redirect href="/(tabs)/home" />;
+  const { theme } = useTheme();
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const isReady = useAuthStore(selectAuthIsReady);
+  const setUser = useAuthStore((s) => s.setUser);
+  const setReady = useAuthStore((s) => s.setReady);
+
+  // On mount, try to restore auth from stored token / silent sign-in
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const token = await getAuthToken();
+        if (token) {
+          // Try silent refresh to get latest user info
+          const user = await silentSignIn();
+          if (user) {
+            setUser({
+              id: user.id,
+              email: user.email,
+              name: user.name,
+              photo: user.photo,
+              provider: 'google',
+            });
+          }
+        }
+      } catch {
+        // Silent sign-in failed — user will need to sign in manually
+      } finally {
+        setReady();
+      }
+    }
+
+    if (!isReady) {
+      checkAuth();
+    }
+  }, [isReady, setUser, setReady]);
+
+  // Show loading while checking auth
+  if (!isReady) {
+    return (
+      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  // Redirect based on auth state
+  if (isAuthenticated) {
+    return <Redirect href="/(tabs)/home" />;
+  }
+
+  return <Redirect href={'/signin' as never} />;
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/apps/mobile/app/signin.tsx
+++ b/apps/mobile/app/signin.tsx
@@ -1,0 +1,172 @@
+/**
+ * Sign-in screen.
+ *
+ * Provides Google and Apple sign-in buttons. On successful auth,
+ * stores the user in the auth store and redirects to the main app.
+ */
+
+import { useCallback, useState } from 'react';
+import { Alert, Platform, StyleSheet, Text, View } from 'react-native';
+import { router } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+import { useTheme } from '../src/theme';
+import { Button } from '../src/components/ui/Button';
+import { useAuthStore } from '../src/stores/auth-store';
+import {
+  signInWithGoogle,
+  signInWithApple,
+  GoogleAuthError,
+  AppleAuthError,
+} from '../src/services/auth';
+
+export default function SignInScreen() {
+  const { theme } = useTheme();
+  const setUser = useAuthStore((s) => s.setUser);
+  const setError = useAuthStore((s) => s.setError);
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const [appleAvailable] = useState(() => Platform.OS === 'ios');
+
+  const handleGoogleSignIn = useCallback(async () => {
+    setIsSigningIn(true);
+    setError(null);
+    try {
+      const googleUser = await signInWithGoogle();
+      setUser({
+        id: googleUser.id,
+        email: googleUser.email,
+        name: googleUser.name,
+        photo: googleUser.photo,
+        provider: 'google',
+      });
+      router.replace('/(tabs)/home' as never);
+    } catch (err) {
+      if (err instanceof GoogleAuthError && err.code === 'SIGN_IN_CANCELLED') {
+        // User cancelled — don't show error
+        setIsSigningIn(false);
+        return;
+      }
+      const message = err instanceof Error ? err.message : 'Google Sign-In failed';
+      setError(message);
+      Alert.alert('Sign-In Failed', message);
+    } finally {
+      setIsSigningIn(false);
+    }
+  }, [setUser, setError]);
+
+  const handleAppleSignIn = useCallback(async () => {
+    setIsSigningIn(true);
+    setError(null);
+    try {
+      const appleUser = await signInWithApple();
+      setUser({
+        id: appleUser.id,
+        email: appleUser.email,
+        name: appleUser.fullName,
+        photo: null,
+        provider: 'apple',
+      });
+      router.replace('/(tabs)/home' as never);
+    } catch (err) {
+      if (err instanceof AppleAuthError && err.code === 'SIGN_IN_CANCELLED') {
+        setIsSigningIn(false);
+        return;
+      }
+      const message = err instanceof Error ? err.message : 'Apple Sign-In failed';
+      setError(message);
+      Alert.alert('Sign-In Failed', message);
+    } finally {
+      setIsSigningIn(false);
+    }
+  }, [setUser, setError]);
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      testID="signin-screen"
+    >
+      <View style={styles.content}>
+        {/* Logo / Branding */}
+        <View style={styles.branding}>
+          <Ionicons name="document-text" size={64} color={theme.colors.primary} />
+          <Text
+            style={[
+              theme.typography.displayLarge,
+              { color: theme.colors.onBackground, marginTop: theme.spacing.md },
+            ]}
+          >
+            FillIt
+          </Text>
+          <Text
+            style={[
+              theme.typography.bodyLarge,
+              {
+                color: theme.colors.onSurfaceVariant,
+                marginTop: theme.spacing.sm,
+                textAlign: 'center',
+              },
+            ]}
+          >
+            Scan, fill, and sign documents{'\n'}in seconds.
+          </Text>
+        </View>
+
+        {/* Sign-in buttons */}
+        <View style={[styles.buttons, { marginTop: theme.spacing['3xl'] }]}>
+          <Button
+            label={isSigningIn ? 'Signing in...' : 'Continue with Google'}
+            variant="outline"
+            size="lg"
+            onPress={handleGoogleSignIn}
+            disabled={isSigningIn}
+            iconLeft={<Ionicons name="logo-google" size={20} color={theme.colors.onSurface} />}
+            fullWidth
+            testID="signin-google-button"
+          />
+
+          {appleAvailable ? (
+            <Button
+              label={isSigningIn ? 'Signing in...' : 'Continue with Apple'}
+              variant="outline"
+              size="lg"
+              onPress={handleAppleSignIn}
+              disabled={isSigningIn}
+              iconLeft={<Ionicons name="logo-apple" size={20} color={theme.colors.onSurface} />}
+              fullWidth
+              testID="signin-apple-button"
+              style={{ marginTop: theme.spacing.md }}
+            />
+          ) : null}
+        </View>
+
+        {/* Footer */}
+        <Text
+          style={[
+            theme.typography.bodySmall,
+            {
+              color: theme.colors.onSurfaceVariant,
+              textAlign: 'center',
+              marginTop: theme.spacing['2xl'],
+            },
+          ]}
+        >
+          By signing in, you agree to our Terms of Service{'\n'}and Privacy Policy.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  content: {
+    paddingHorizontal: 32,
+  },
+  branding: {
+    alignItems: 'center',
+  },
+  buttons: {},
+});

--- a/apps/mobile/src/stores/__tests__/auth-store.test.ts
+++ b/apps/mobile/src/stores/__tests__/auth-store.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for auth store.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock AsyncStorage
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn().mockResolvedValue(null),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+import { useAuthStore, type AuthUser } from '../auth-store';
+
+describe('auth-store', () => {
+  beforeEach(() => {
+    useAuthStore.getState().reset();
+  });
+
+  const mockUser: AuthUser = {
+    id: 'user-123',
+    email: 'test@example.com',
+    name: 'Test User',
+    photo: 'https://photo.url',
+    provider: 'google',
+  };
+
+  describe('setUser', () => {
+    it('should set authenticated user', () => {
+      useAuthStore.getState().setUser(mockUser);
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.user).toEqual(mockUser);
+      expect(state.provider).toBe('google');
+      expect(state.error).toBeNull();
+    });
+
+    it('should clear loading state on set', () => {
+      useAuthStore.setState({ isLoading: true });
+      useAuthStore.getState().setUser(mockUser);
+
+      expect(useAuthStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('clearUser', () => {
+    it('should clear auth state', () => {
+      useAuthStore.getState().setUser(mockUser);
+      useAuthStore.getState().clearUser();
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.user).toBeNull();
+      expect(state.provider).toBeNull();
+    });
+  });
+
+  describe('setLoading', () => {
+    it('should set loading state', () => {
+      useAuthStore.getState().setLoading(true);
+      expect(useAuthStore.getState().isLoading).toBe(true);
+
+      useAuthStore.getState().setLoading(false);
+      expect(useAuthStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('setReady', () => {
+    it('should mark auth as ready', () => {
+      expect(useAuthStore.getState().isReady).toBe(false);
+
+      useAuthStore.getState().setReady();
+
+      expect(useAuthStore.getState().isReady).toBe(true);
+    });
+  });
+
+  describe('setError', () => {
+    it('should set error and clear loading', () => {
+      useAuthStore.setState({ isLoading: true });
+      useAuthStore.getState().setError('Auth failed');
+
+      const state = useAuthStore.getState();
+      expect(state.error).toBe('Auth failed');
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('should clear error', () => {
+      useAuthStore.getState().setError('Some error');
+      useAuthStore.getState().setError(null);
+
+      expect(useAuthStore.getState().error).toBeNull();
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset to default state', () => {
+      useAuthStore.getState().setUser(mockUser);
+      useAuthStore.getState().setReady();
+      useAuthStore.getState().reset();
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.user).toBeNull();
+      expect(state.isReady).toBe(false);
+    });
+  });
+
+  describe('Apple provider', () => {
+    it('should handle Apple user', () => {
+      const appleUser: AuthUser = {
+        id: 'apple-user',
+        email: 'xyz@privaterelay.appleid.com',
+        name: 'John Doe',
+        photo: null,
+        provider: 'apple',
+      };
+
+      useAuthStore.getState().setUser(appleUser);
+
+      expect(useAuthStore.getState().provider).toBe('apple');
+      expect(useAuthStore.getState().user?.email).toBe('xyz@privaterelay.appleid.com');
+    });
+  });
+});

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -1,0 +1,119 @@
+/**
+ * Auth Zustand store with AsyncStorage persistence.
+ *
+ * Manages authentication state: current user, provider, token,
+ * and loading states. Persists auth across app restarts.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export type AuthProvider = 'google' | 'apple' | null;
+
+export interface AuthUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+  photo: string | null;
+  provider: AuthProvider;
+}
+
+export interface AuthState {
+  /** The currently authenticated user. */
+  user: AuthUser | null;
+  /** The current auth provider. */
+  provider: AuthProvider;
+  /** Whether the user is authenticated. */
+  isAuthenticated: boolean;
+  /** Whether auth state is being loaded/verified. */
+  isLoading: boolean;
+  /** Whether initial auth check has completed. */
+  isReady: boolean;
+  /** Auth error message. */
+  error: string | null;
+}
+
+export interface AuthActions {
+  /** Set the authenticated user after successful sign-in. */
+  setUser: (user: AuthUser) => void;
+  /** Clear auth state (sign-out). */
+  clearUser: () => void;
+  /** Set loading state. */
+  setLoading: (isLoading: boolean) => void;
+  /** Mark auth as ready (initial check complete). */
+  setReady: () => void;
+  /** Set error message. */
+  setError: (error: string | null) => void;
+  /** Reset the entire auth state. */
+  reset: () => void;
+}
+
+export type AuthStore = AuthState & AuthActions;
+
+// ─── Defaults ─────────────────────────────────────────────────────
+
+const DEFAULT_AUTH_STATE: AuthState = {
+  user: null,
+  provider: null,
+  isAuthenticated: false,
+  isLoading: false,
+  isReady: false,
+  error: null,
+};
+
+// ─── Store ────────────────────────────────────────────────────────
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set) => ({
+      ...DEFAULT_AUTH_STATE,
+
+      setUser: (user: AuthUser) =>
+        set({
+          user,
+          provider: user.provider,
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+        }),
+
+      clearUser: () =>
+        set({
+          user: null,
+          provider: null,
+          isAuthenticated: false,
+          isLoading: false,
+          error: null,
+        }),
+
+      setLoading: (isLoading: boolean) => set({ isLoading }),
+
+      setReady: () => set({ isReady: true }),
+
+      setError: (error: string | null) => set({ error, isLoading: false }),
+
+      reset: () => set({ ...DEFAULT_AUTH_STATE }),
+    }),
+    {
+      name: 'fillit-auth',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        user: state.user,
+        provider: state.provider,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    },
+  ),
+);
+
+// ─── Selectors ────────────────────────────────────────────────────
+
+export const selectIsAuthenticated = (state: AuthStore): boolean => state.isAuthenticated;
+export const selectAuthUser = (state: AuthStore): AuthUser | null => state.user;
+export const selectAuthProvider = (state: AuthStore): AuthProvider => state.provider;
+export const selectAuthIsLoading = (state: AuthStore): boolean => state.isLoading;
+export const selectAuthIsReady = (state: AuthStore): boolean => state.isReady;
+export const selectAuthError = (state: AuthStore): string | null => state.error;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6095,9 +6095,7 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.83.2': {}
 


### PR DESCRIPTION
## Summary
- Adds `auth-store` (Zustand + AsyncStorage) to persist auth state across app restarts
- Adds sign-in screen with Google and Apple sign-in buttons (Apple shown on iOS only)
- Converts root index screen into an auth guard:
  - On launch: checks stored token → attempts silent sign-in refresh → redirects
  - Authenticated → main app (tabs)
  - Unauthenticated → sign-in screen
- Loading spinner during initial auth verification
- Cancelled sign-ins handled gracefully (no error alert)
- FillIt branding on sign-in screen with tagline
- 9 tests covering auth store actions, providers, and state transitions

Closes #59

## Test plan
- [ ] Run `vitest run src/stores/__tests__/auth-store.test.ts` — 9 tests pass
- [ ] Fresh install → lands on sign-in screen
- [ ] Sign in with Google → redirects to home tab
- [ ] Sign in with Apple (iOS) → redirects to home tab
- [ ] Kill and reopen app → stays signed in (persisted)
- [ ] Cancel sign-in → stays on sign-in screen, no error shown
- [ ] Sign out (when implemented) → returns to sign-in screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)